### PR TITLE
Fix invalid assignment of Frost Mage damage spell.

### DIFF
--- a/FrostMageBot/CombatState.cs
+++ b/FrostMageBot/CombatState.cs
@@ -46,11 +46,13 @@ namespace FrostMageBot
             player = ObjectManager.Player;
             this.target = target;
 
-            if (player.Level >= 8)
-                nuke = Frostbolt;
-            else if (player.Level >= 6 || !player.KnowsSpell(Frostbolt))
+            if (!player.KnowsSpell(Frostbolt))
                 nuke = Fireball;
-            else if (player.Level >= 4 && player.KnowsSpell(Frostbolt))
+            else if (player.Level >= 8)
+                nuke = Frostbolt;
+            else if (player.Level >= 6)
+                nuke = Fireball;
+            else if (player.Level >= 4)
                 nuke = Frostbolt;
             else
                 nuke = Fireball;


### PR DESCRIPTION
Currently, a bot will use Frostbolt as the fallback damage dealing spell when Frost Mage is selected. However, with a fresh character they can make it to level 8 in a small amount of time and may not have trained the spell. Combat state does not cast any known spells in this case, causing a death loop.

There are multiple ways we could handle the flow for checking level to select fireball or frostbolt, so the checks could be reworked in a variety of ways. I felt checking that the character has learned frostbolt as a check before the others was reasonable given none of the rest of the logic for the check applies if the character doesn't know that spell yet. The other checks seem to be maximizing DPS for the applicable levels. 

Issue #8 
Tested on WoW Client Version: Vanilla (server is mangos-based).