### PR TITLE
Ability to use local SQLite database, automatic database structure setup, Discord bot disabling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -280,3 +280,4 @@ main.min.css
 *.min.js
 
 Bot
+/BloogBot/UI/App.xaml.cs

--- a/BloogBot.sln
+++ b/BloogBot.sln
@@ -57,7 +57,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_SolutionItems", "_Solution
 		Bot\bootstrapperSettings.json = Bot\bootstrapperSettings.json
 		Bot\botSettings.json = Bot\botSettings.json
 		README.md = README.md
-		SqlSchema.SQL = SqlSchema.SQL
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BloogBotTests", "BloogBotTests\BloogBotTests.csproj", "{827E1CEE-7D53-4E99-BC27-9890995040C8}"
@@ -137,6 +136,7 @@ Global
 		{339B8C16-CAD4-467B-B1F3-F10F7E80F944}.Debug|x86.ActiveCfg = Debug|Win32
 		{339B8C16-CAD4-467B-B1F3-F10F7E80F944}.Debug|x86.Build.0 = Debug|Win32
 		{339B8C16-CAD4-467B-B1F3-F10F7E80F944}.Release|Any CPU.ActiveCfg = Release|Win32
+		{339B8C16-CAD4-467B-B1F3-F10F7E80F944}.Release|Any CPU.Build.0 = Release|Win32
 		{339B8C16-CAD4-467B-B1F3-F10F7E80F944}.Release|x64.ActiveCfg = Release|x64
 		{339B8C16-CAD4-467B-B1F3-F10F7E80F944}.Release|x64.Build.0 = Release|x64
 		{339B8C16-CAD4-467B-B1F3-F10F7E80F944}.Release|x86.ActiveCfg = Release|Win32
@@ -340,6 +340,7 @@ Global
 		{C817858E-0656-4211-934B-C672998EDDB3}.Debug|x86.ActiveCfg = Debug|Win32
 		{C817858E-0656-4211-934B-C672998EDDB3}.Debug|x86.Build.0 = Debug|Win32
 		{C817858E-0656-4211-934B-C672998EDDB3}.Release|Any CPU.ActiveCfg = Release|Win32
+		{C817858E-0656-4211-934B-C672998EDDB3}.Release|Any CPU.Build.0 = Release|Win32
 		{C817858E-0656-4211-934B-C672998EDDB3}.Release|x64.ActiveCfg = Release|x64
 		{C817858E-0656-4211-934B-C672998EDDB3}.Release|x64.Build.0 = Release|x64
 		{C817858E-0656-4211-934B-C672998EDDB3}.Release|x86.ActiveCfg = Release|Win32

--- a/BloogBot/AI/Bot.cs
+++ b/BloogBot/AI/Bot.cs
@@ -8,7 +8,9 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.Serialization;
 using System.Threading.Tasks;
+using ObjectManager = BloogBot.Game.ObjectManager;
 
 namespace BloogBot.AI
 {
@@ -16,7 +18,7 @@ namespace BloogBot.AI
     {
         readonly Stack<IBotState> botStates = new Stack<IBotState>();
         readonly Stopwatch stopwatch = new Stopwatch();
-
+        
         bool running;
         bool retrievingCorpse;
 
@@ -310,6 +312,12 @@ namespace BloogBot.AI
                         {
                             currentLevel = player.Level;
                             DiscordClientWrapper.SendMessage($"Ding! {player.Name} is now level {player.Level}!");
+                        }
+
+                        if(ObjectManager.Aggressors.Count() > 0 && player.Target.Guid != ObjectManager.Aggressors.First().Guid) 
+                        {
+                            player.SetTarget(ObjectManager.Aggressors.First().Guid);
+                            botStates.Push(container.CreateMoveToTargetState(botStates, container, ObjectManager.Aggressors.First()));
                         }
 
                         player.AntiAfk();

--- a/BloogBot/AI/SharedStates/EquipBagsState.cs
+++ b/BloogBot/AI/SharedStates/EquipBagsState.cs
@@ -23,7 +23,7 @@ namespace BloogBot.AI.SharedStates
         {
             if (ObjectManager.Player.IsInCombat)
             {
-                botStates.Pop();
+                //botStates.Pop();
                 return;
             }
 

--- a/BloogBot/AI/SharedStates/GatherObjectState.cs
+++ b/BloogBot/AI/SharedStates/GatherObjectState.cs
@@ -8,13 +8,13 @@ namespace BloogBot.AI.SharedStates
     class GatherObjectState : IBotState
     {
         readonly Stack<IBotState> botStates;
-        readonly WoWGameObject target;
+        readonly dynamic target;
         readonly LocalPlayer player;
         readonly int initialCount = 0;
 
         readonly int startTime = Environment.TickCount;
 
-        internal GatherObjectState(Stack<IBotState> botStates, IDependencyContainer container, WoWGameObject target)
+        internal GatherObjectState(Stack<IBotState> botStates, IDependencyContainer container, dynamic target)
         {
             this.botStates = botStates;
             this.target = target;
@@ -26,7 +26,7 @@ namespace BloogBot.AI.SharedStates
         {
             if (player.IsInCombat || (Environment.TickCount - startTime > 15000))
             {
-                botStates.Pop();
+                //botStates.Pop();
                 return;
             }
 

--- a/BloogBot/AI/SharedStates/LootState.cs
+++ b/BloogBot/AI/SharedStates/LootState.cs
@@ -65,8 +65,16 @@ namespace BloogBot.AI.SharedStates
             //  - loot frame is open, but we've already looted everything we want
             //  - stuck count is greater than 5 (perhaps the corpse is in an awkward position the character can't reach)
             //  - we've been in the loot state for over 10 seconds (again, perhaps the corpse is unreachable. most common example of this is when a mob dies on a cliff that we can't climb)
-            if ((currentState == LootStates.Initial && !target.CanBeLooted) || (lootFrame != null && lootIndex == lootFrame.LootItems.Count) || stuckCount > 5 || Environment.TickCount - startTime > 10000)
+            if (((currentState == LootStates.Initial && !target.CanBeLooted) || (lootFrame != null && lootIndex == lootFrame.LootItems.Count) || stuckCount > 5 || Environment.TickCount - startTime > 10000) && !player.IsCasting)
             {
+                if (target.CanBeSkinned && currentState != LootStates.Gathering && player.KnowsSpell("Skinning"))
+                {
+                    botStates.Push(new GatherObjectState(botStates, container, target));
+                    currentState = LootStates.Gathering;
+                    return;
+                }
+
+
                 player.StopAllMovement();
                 botStates.Pop();
                 botStates.Push(new EquipBagsState(botStates, container));
@@ -123,6 +131,7 @@ namespace BloogBot.AI.SharedStates
     {
         Initial,
         RightClicked,
-        LootFrameReady
+        LootFrameReady,
+        Gathering
     }
 }

--- a/BloogBot/App.config
+++ b/BloogBot/App.config
@@ -1,9 +1,25 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
-    </startup>
-	<runtime>
-		<legacyCorruptedStateExceptionsPolicy enabled="true" />
-	</runtime>
+  <configSections>
+    <!-- For more information on Entity Framework configuration, visit http://go.microsoft.com/fwlink/?LinkID=237468 -->
+    <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
+  </configSections>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+  </startup>
+  <runtime>
+    <legacyCorruptedStateExceptionsPolicy enabled="true" />
+  </runtime>
+  <entityFramework>
+    <providers>
+      <provider invariantName="System.Data.SqlClient" type="System.Data.Entity.SqlServer.SqlProviderServices, EntityFramework.SqlServer" />
+      <provider invariantName="System.Data.SQLite.EF6" type="System.Data.SQLite.EF6.SQLiteProviderServices, System.Data.SQLite.EF6" />
+    </providers>
+  </entityFramework>
+  <system.data>
+    <DbProviderFactories>
+      <remove invariant="System.Data.SQLite.EF6" />
+      <add name="SQLite Data Provider (Entity Framework 6)" invariant="System.Data.SQLite.EF6" description=".NET Framework Data Provider for SQLite (Entity Framework 6)" type="System.Data.SQLite.EF6.SQLiteProviderFactory, System.Data.SQLite.EF6" />
+    <remove invariant="System.Data.SQLite" /><add name="SQLite Data Provider" invariant="System.Data.SQLite" description=".NET Framework Data Provider for SQLite" type="System.Data.SQLite.SQLiteFactory, System.Data.SQLite" /></DbProviderFactories>
+  </system.data>
 </configuration>

--- a/BloogBot/BloogBot.csproj
+++ b/BloogBot/BloogBot.csproj
@@ -155,6 +155,7 @@
     <Compile Include="BotSettings.cs" />
     <Compile Include="ClientHelper.cs" />
     <Compile Include="CommandModel.cs" />
+    <Compile Include="DatabaseWrapper.cs" />
     <Compile Include="Detour.cs" />
     <Compile Include="DiscordClientWrapper.cs" />
     <Compile Include="Game\Cache\ItemCacheInfo.cs" />
@@ -253,10 +254,10 @@
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
     <None Include="bootstrapperSettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="botSettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
@@ -278,6 +279,12 @@
   <ItemGroup>
     <Content Include="Fasm.NET.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TSqlSchema.SQL">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="SqliteSchema.SQL">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
   <ItemGroup>

--- a/BloogBot/BloogBot.csproj
+++ b/BloogBot/BloogBot.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\EntityFramework.6.4.4\build\EntityFramework.props" Condition="Exists('..\packages\EntityFramework.6.4.4\build\EntityFramework.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -63,6 +64,12 @@
     <Reference Include="Discord.Net.WebSocket, Version=2.2.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Discord.Net.WebSocket.2.2.0\lib\net461\Discord.Net.WebSocket.dll</HintPath>
     </Reference>
+    <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\EntityFramework.6.4.4\lib\net45\EntityFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="EntityFramework.SqlServer, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\EntityFramework.6.4.4\lib\net45\EntityFramework.SqlServer.dll</HintPath>
+    </Reference>
     <Reference Include="Fasm.NET, Version=1.0.5697.28632, Culture=neutral, processorArchitecture=x86">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\Bot\Fasm.NET.dll</HintPath>
@@ -78,7 +85,17 @@
       <HintPath>..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Data.SQLite, Version=1.0.117.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
+      <HintPath>..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.117.0\lib\net46\System.Data.SQLite.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Data.SQLite.EF6, Version=1.0.117.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Data.SQLite.EF6.1.0.117.0\lib\net46\System.Data.SQLite.EF6.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Data.SQLite.Linq, Version=1.0.117.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Data.SQLite.Linq.1.0.117.0\lib\net46\System.Data.SQLite.Linq.dll</HintPath>
+    </Reference>
     <Reference Include="System.Interactive.Async, Version=4.0.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Interactive.Async.4.0.0\lib\net461\System.Interactive.Async.dll</HintPath>
     </Reference>
@@ -276,4 +293,14 @@
     </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\EntityFramework.6.4.4\build\EntityFramework.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\EntityFramework.6.4.4\build\EntityFramework.props'))" />
+    <Error Condition="!Exists('..\packages\EntityFramework.6.4.4\build\EntityFramework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\EntityFramework.6.4.4\build\EntityFramework.targets'))" />
+    <Error Condition="!Exists('..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.117.0\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.117.0\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets'))" />
+  </Target>
+  <Import Project="..\packages\EntityFramework.6.4.4\build\EntityFramework.targets" Condition="Exists('..\packages\EntityFramework.6.4.4\build\EntityFramework.targets')" />
+  <Import Project="..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.117.0\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets" Condition="Exists('..\packages\Stub.System.Data.SQLite.Core.NetFramework.1.0.117.0\build\net46\Stub.System.Data.SQLite.Core.NetFramework.targets')" />
 </Project>

--- a/BloogBot/BotSettings.cs
+++ b/BloogBot/BotSettings.cs
@@ -5,7 +5,10 @@ namespace BloogBot
 {
     public class BotSettings
     {
+        public string DatabaseType { get; set; }
         public string DatabasePath { get; set; }
+
+        public bool DiscordBotEnabled { get; set; }
 
         public string DiscordBotToken { get; set; }
 

--- a/BloogBot/DatabaseWrapper.cs
+++ b/BloogBot/DatabaseWrapper.cs
@@ -1,0 +1,876 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Data.SQLite;
+using System.IO;
+using System.Reflection;
+using BloogBot.Game;
+using Newtonsoft.Json;
+
+namespace BloogBot
+{
+    internal class DatabaseWrapper
+    {
+        private string connectionString;
+        private string databaseType;
+        public enum DataOperation
+        {
+            SELECT,
+            INSERT
+        }
+        public DatabaseWrapper(string dbType, string connString)
+        {
+            databaseType = dbType.ToLower();
+            connectionString = connString;
+            this.Initialize();
+        }
+        public bool IsSQL()
+        {
+            return databaseType.Contains("sql");
+        }
+        public void Initialize()
+        {
+
+            string strExeFilePath = Assembly.GetExecutingAssembly().Location;
+            string strWorkPath = Path.GetDirectoryName(strExeFilePath);
+
+            switch (databaseType)
+            {
+                case "sqlite":
+                    string dbPath = Path.Combine(strWorkPath, "db.db");
+                    connectionString = String.Format("Data Source={0};Version=3;New=True;Compress=True;", dbPath);
+                    if (!File.Exists(dbPath))
+                    {
+                        SQLiteConnection.CreateFile(dbPath);
+                        using (var db = this.NewConnection())
+                        {
+                            string script = File.ReadAllText(Path.Combine(strWorkPath, "SqliteSchema.SQL"));
+                            var command = this.NewCommand(script, db);
+                            db.Open();
+                            command.ExecuteNonQuery();
+                            db.Close();
+                        }
+                    }
+                    break;
+                case "mssql":
+                    using (var db = this.NewConnection())
+                    {
+                        string script = File.ReadAllText(Path.Combine(strWorkPath, "TSqlSchema.SQL"));
+                        var command = this.NewCommand(script, db);
+                        db.Open();
+                        command.ExecuteNonQuery();
+                        db.Close();
+                    }
+                    break;
+            }
+        }
+
+        public dynamic NewConnection()
+        {
+            switch (databaseType)
+            {
+                case "sqlite":
+                    return new SQLiteConnection(connectionString);
+                case "mssql":
+                    return new SqlConnection(connectionString);
+            }
+            return null;
+        }
+
+        public dynamic NewCommand(string sql, dynamic db)
+        {
+            switch (databaseType)
+            {
+                case "sqlite":
+                    return new SQLiteCommand(sql, db);
+                case "mssql":
+                    return new SqlCommand(sql, db);
+                default:
+                    // Should be unreachable if configured correctly - Code can be extended or removed for alternative storage types.
+                    throw new NotImplementedException();
+            }
+        }
+
+        public Npc AddNpc(string name,
+            bool isInnkeeper,
+            bool sellsAmmo,
+            bool repairs,
+            bool quest,
+            bool horde,
+            bool alliance,
+            float positionX,
+            float positionY,
+            float positionZ,
+            string zone)
+        {
+
+            string insertSql;
+            string selectSql;
+            switch (databaseType)
+            {
+                case "sqlite":
+                    insertSql = $"INSERT INTO Npcs (Name, IsInnKeeper, SellsAmmo, Repairs, Quest, Horde, Alliance, PositionX, PositionY, PositionZ, Zone) VALUES ('{name}', {Convert.ToInt32(isInnkeeper)}, {Convert.ToInt32(sellsAmmo)}, {Convert.ToInt32(repairs)}, {Convert.ToInt32(quest)}, {Convert.ToInt32(horde)}, {Convert.ToInt32(alliance)}, {positionX}, {positionY}, {positionZ}, '{zone}');";
+                    selectSql = $"SELECT * FROM Npcs WHERE Name = '{name}' LIMIT 1;";
+                    this.SqlQuery(insertSql);
+                    break;
+                case "mssql":
+                    insertSql = $"INSERT INTO Npcs VALUES ('{name}', {Convert.ToInt32(isInnkeeper)}, {Convert.ToInt32(sellsAmmo)}, {Convert.ToInt32(repairs)}, {Convert.ToInt32(quest)}, {Convert.ToInt32(horde)}, {Convert.ToInt32(alliance)}, {positionX}, {positionY}, {positionZ}, '{zone}');";
+                    selectSql = $"SELECT TOP 1 * FROM Npcs WHERE Name = '{name}';";
+                    this.SqlQuery(insertSql);
+                    break;
+                default:
+                    // Should be unreachable if configured correctly - Code can be extended or removed for alternative storage types.
+                    throw new NotImplementedException();
+            }
+            if (this.IsSQL())
+            {
+                using (var db = this.NewConnection())
+                {
+                    db.Open();
+                    var command = this.NewCommand(selectSql, db);
+                    var reader = command.ExecuteReader();
+                    reader.Read();
+
+                    var id = Convert.ToInt32(reader["Id"]);
+                    var npc = new Npc(id,
+                        name,
+                        isInnkeeper,
+                        sellsAmmo,
+                        repairs,
+                        quest,
+                        horde,
+                        alliance,
+                        new Position(positionX, positionY, positionZ),
+                        zone);
+
+                    reader.Close();
+                    db.Close();
+
+                    return npc;
+                }
+            }
+            else
+            {
+                // Should be unreachable if configured correctly - Code can be extended or removed for alternative storage types.
+                throw new NotImplementedException();
+            }
+        }
+
+        public bool RowExistsSql(string sql)
+        {
+            if (this.IsSQL())
+            {
+                using (var db = this.NewConnection())
+                {
+                    db.Open();
+
+                    var command = this.NewCommand(sql, db);
+                    var exists = command.ExecuteReader().HasRows;
+
+                    db.Close();
+
+                    return exists;
+                }
+            }
+            else
+            {
+                // Should be unreachable if configured correctly - Code can be extended or removed for alternative storage types.
+                throw new NotImplementedException();
+            }
+        }
+
+        public void SqlQuery(string sql)
+        {
+            if (this.IsSQL())
+            {
+                using (var db = this.NewConnection())
+                {
+                    db.Open();
+
+                    var command = this.NewCommand(sql, db);
+                    command.Prepare();
+                    command.ExecuteNonQuery();
+
+                    db.Close();
+                }
+            }
+            else
+            {
+                // Should be unreachable if configured correctly - Code can be extended or removed for alternative storage types.
+                throw new NotImplementedException();
+            }
+        }
+
+        public bool NpcExists(string name)
+        {
+            string sql;
+            switch (databaseType)
+            {
+                case "sqlite":
+                    sql = $"SELECT Id FROM Npcs WHERE Name = '{name}' LIMIT 1;";
+                    return this.RowExistsSql(sql);
+                case "mssql":
+                    sql = $"SELECT TOP 1 Id FROM Npcs WHERE Name = '{name}';";
+                    return this.RowExistsSql(sql);
+                default:
+                    // Should be unreachable if configured correctly - Code can be extended or removed for alternative storage types.
+                    throw new NotImplementedException();
+            }
+        }
+        public bool BlacklistedMobExists(ulong guid)
+        {
+            string sql;
+            switch (databaseType)
+            {
+                case "sqlite":
+                    sql = $"SELECT Id FROM BlacklistedMobs WHERE Guid = '{guid}' LIMIT 1;";
+                    return this.RowExistsSql(sql);
+                case "mssql":
+                    sql = $"SELECT TOP 1 Id FROM BlacklistedMobs WHERE Guid = '{guid}';";
+                    return this.RowExistsSql(sql);
+                default:
+                    // Should be unreachable if configured correctly - Code can be extended or removed for alternative storage types.
+                    throw new NotImplementedException();
+            }
+        }
+
+        public bool TravelPathExists(string name)
+        {
+            string sql;
+            switch (databaseType)
+            {
+                case "sqlite":
+                    sql = $"SELECT Id FROM TravelPaths WHERE Name = '{name}' LIMIT 1";
+                    return this.RowExistsSql(sql);
+                case "mssql":
+                    sql = $"SELECT TOP 1 Id FROM TravelPaths WHERE Name = '{name}'";
+                    return this.RowExistsSql(sql);
+                default:
+                    // Should be unreachable if configured correctly - Code can be extended or removed for alternative storage types.
+                    throw new NotImplementedException();
+            }
+        }
+
+        public TravelPath AddTravelPath(string name, string waypointsJson)
+        {
+            string insertSql;
+            string selectSql;
+            switch (databaseType)
+            {
+                case "sqlite":
+                    insertSql = $"INSERT INTO TravelPaths (Name, Waypoints) VALUES ('{name}', '{waypointsJson}');";
+                    selectSql = $"SELECT * FROM TravelPaths WHERE Name = '{name}' LIMIT 1;";
+                    this.SqlQuery(insertSql);
+                    break;
+                case "mssql":
+                    insertSql = $"INSERT INTO TravelPaths VALUES ('{name}', '{waypointsJson}');";
+                    selectSql = $"SELECT TOP 1 * FROM TravelPaths WHERE Name = '{name}';";
+                    this.SqlQuery(insertSql);
+                    break;
+                default:
+                    // Should be unreachable if configured correctly - Code can be extended or removed for alternative storage types.
+                    throw new NotImplementedException();
+            }
+
+
+            Position[] waypoints = JsonConvert.DeserializeObject<Position[]>(waypointsJson);
+
+            if (this.IsSQL())
+            {
+                using (var db = this.NewConnection())
+                {
+                    db.Open();
+                    var command = this.NewCommand(selectSql, db);
+                    var reader = command.ExecuteReader();
+                    reader.Read();
+
+                    var id = Convert.ToInt32(reader["Id"]);
+                    var travelPath = new TravelPath(id, name, waypoints);
+
+                    reader.Close();
+                    db.Close();
+
+                    return travelPath;
+                }
+            }
+            else
+            {
+                // Should be unreachable if configured correctly - Code can be extended or removed for alternative storage types.
+                throw new NotImplementedException();
+            }
+
+        }
+
+
+        public List<TravelPath> ListTravelPaths()
+        {
+            string sql;
+            switch (databaseType)
+            {
+                case "sqlite":
+                case "mssql":
+                    sql = $"SELECT * FROM TravelPaths ORDER BY Name";
+                    break;
+                default:
+                    // Should be unreachable if configured correctly - Code can be extended or removed for alternative storage types.
+                    throw new NotImplementedException();
+            }
+
+            var travelPaths = new List<TravelPath>();
+            if (this.IsSQL())
+            {
+                using (var db = this.NewConnection())
+                {
+                    db.Open();
+
+                    var command = this.NewCommand(sql, db);
+                    var reader = command.ExecuteReader();
+                    while (reader.Read())
+                    {
+                        var id = Convert.ToInt32(reader["Id"]);
+                        var name = Convert.ToString(reader["Name"]);
+                        var waypointsJson = Convert.ToString(reader["Waypoints"]);
+                        var waypoints = JsonConvert.DeserializeObject<Position[]>(waypointsJson);
+                        travelPaths.Add(new TravelPath(id, name, waypoints));
+                    }
+
+                    reader.Close();
+                    db.Close();
+
+                    return travelPaths;
+                }
+            }
+            else
+            {
+                // Should be unreachable if configured correctly - Code can be extended or removed for alternative storage types.
+                throw new NotImplementedException();
+            }
+        }
+
+
+        public Hotspot AddHotspot(
+            string description, string zone = "",
+            string faction = "",
+            string waypointsJson = "",
+            Npc innkeeper = null,
+            Npc repairVendor = null,
+            Npc ammoVendor = null,
+            int minLevel = 0,
+            TravelPath travelPath = null,
+            bool safeForGrinding = false,
+            Position[] waypoints = null
+            )
+        {
+
+            string insertSql;
+            string selectSql;
+            int id;
+
+            switch (databaseType)
+            {
+                case "sqlite":
+                    insertSql = $"INSERT INTO Hotspots (Zone, Description, Faction, Waypoints, InnkeeperId, RepairVendorId, AmmoVendorId, MinimumLevel, TravelPathId, SafeForGrinding) VALUES ('{zone}', '{description}', '{faction}', '{waypointsJson}', {innkeeper?.Id.ToString() ?? "NULL"}, {repairVendor?.Id.ToString() ?? "NULL"}, {ammoVendor?.Id.ToString() ?? "NULL"}, {minLevel}, {travelPath?.Id.ToString() ?? "NULL"}, {Convert.ToInt32(safeForGrinding)});";
+                    selectSql = $"SELECT * FROM Hotspots WHERE Description = '{description}' LIMIT 1;";
+                    this.SqlQuery(insertSql);
+                    break;
+                case "mssql":
+                    insertSql = $"INSERT INTO Hotspots VALUES ('{zone}', '{description}', '{faction}', '{waypointsJson}', {innkeeper?.Id.ToString() ?? "NULL"}, {repairVendor?.Id.ToString() ?? "NULL"}, {ammoVendor?.Id.ToString() ?? "NULL"}, {minLevel}, {travelPath?.Id.ToString() ?? "NULL"}, {Convert.ToInt32(safeForGrinding)});";
+                    selectSql = $"SELECT TOP 1 * FROM Hotspots WHERE Description = '{description}';";
+                    this.SqlQuery(insertSql);
+                    break;
+                default:
+                    // Should be unreachable if configured correctly - Code can be extended or removed for alternative storage types.
+                    throw new NotImplementedException();
+            }
+
+            if (this.IsSQL())
+            {
+
+                using (var db = this.NewConnection())
+                {
+                    db.Open();
+
+                    var command = this.NewCommand(selectSql, db);
+                    var reader = command.ExecuteReader();
+                    reader.Read();
+
+                    id = Convert.ToInt32(reader["Id"]);
+
+                    reader.Close();
+                    db.Close();
+                }
+            }
+            else
+            {
+                // Should be unreachable if configured correctly - Code can be extended or removed for alternative storage types.
+                throw new NotImplementedException();
+            }
+            return new Hotspot(id, zone, description, faction, minLevel, waypoints, innkeeper, repairVendor, ammoVendor, travelPath, safeForGrinding);
+        }
+
+        public List<Hotspot> ListHotspots()
+        {
+            string sql;
+            List<Hotspot> hotspots = new List<Hotspot>();
+            switch (databaseType)
+            {
+                case "sqlite":
+                case "mssql":
+                    sql = @"
+                    SELECT
+	                    h.Zone, h.Description, h.Faction, h.Waypoints, h.InnkeeperId, h.RepairVendorId, h.AmmoVendorId, h.MinimumLevel, h.TravelPathId, h.SafeForGrinding, h.Id,
+	                    i.Name as Innkeeper_Name, i.IsInnkeeper as Innkeeper_IsInnkeeper, i.SellsAmmo as Innkeeper_SellsAmmo, i.Repairs as Innkeeper_Repairs, i.Quest as Innkeeper_Quest, i.Horde as Innkeeper_Horde, i.Alliance as Innkeeper_Alliance, i.PositionX as Innkeeper_PositionX, i.PositionY as Innkeeper_PositionY, i.PositionZ as Innkeeper_PositionZ, i.Zone as Innkeeper_Zone, i.Id as Innkeeper_Id,
+	                    a.Name as AmmoVendor_Name, a.IsInnkeeper as AmmoVendor_IsInnkeeper, a.SellsAmmo as AmmoVendor_SellsAmmo, a.Repairs as AmmoVendor_Repairs, a.Quest as AmmoVendor_Quest, a.Horde as AmmoVendor_Horde, a.Alliance as AmmoVendor_Alliance, a.PositionX as AmmoVendor_PositionX, a.PositionY as AmmoVendor_PositionY, a.PositionZ as AmmoVendor_PositionZ, a.Zone as AmmoVendor_Zone, a.Id as AmmoVendor_Id,
+	                    r.Name as RepairVendor_Name, r.IsInnkeeper as RepairVendor_IsInnkeeper, r.SellsAmmo as RepairVendor_SellsAmmo, r.Repairs as RepairVendor_Repairs, r.Quest as RepairVendor_Quest, r.Horde as RepairVendor_Horde, r.Alliance as RepairVendor_Alliance, r.PositionX as RepairVendor_PositionX, r.PositionY as RepairVendor_PositionY, r.PositionZ as RepairVendor_PositionZ, r.Zone as RepairVendor_Zone, r.Id as RepairVendor_Id,
+                        t.Name as TravelPath_Name, t.Waypoints as TravelPath_Waypoints, t.Id as TravelPath_Id
+                    FROM Hotspots h
+	                    LEFT JOIN Npcs i ON h.InnkeeperId = i.Id
+	                    LEFT JOIN Npcs a ON h.AmmoVendorId = a.Id
+	                    LEFT JOIN Npcs r ON h.RepairVendorId = r.Id
+                        LEFT JOIN TravelPaths t ON h.TravelPathId = t.Id";
+                    break;
+                default:
+                    throw new NotImplementedException();
+            }
+            if (this.IsSQL())
+            {
+                using (var db = this.NewConnection())
+                {
+                    db.Open();
+
+                    var command = this.NewCommand(sql, db);
+                    var reader = command.ExecuteReader();
+                    while (reader.Read())
+                    {
+                        var id = Convert.ToInt32(reader["Id"]);
+                        var zone = Convert.ToString(reader["Zone"]);
+                        var description = Convert.ToString(reader["Description"]);
+                        var faction = Convert.ToString(reader["Faction"]);
+                        var minLevel = Convert.ToInt32(reader["MinimumLevel"]);
+                        var waypointsJson = Convert.ToString(reader["Waypoints"]);
+                        var waypoints = JsonConvert.DeserializeObject<Position[]>(waypointsJson);
+                        var safeForGrinding = Convert.ToBoolean(reader["SafeForGrinding"]);
+
+                        Npc innkeeper = null;
+                        if (reader["InnkeeperId"].GetType() != typeof(DBNull))
+                            innkeeper = ParseNpcFromQueryResult(reader, Convert.ToInt32(reader["InnkeeperId"]), "Innkeeper_");
+
+                        Npc repairVendor = null;
+                        if (reader["RepairVendorId"].GetType() != typeof(DBNull))
+                            repairVendor = ParseNpcFromQueryResult(reader, Convert.ToInt32(reader["RepairVendorId"]), "RepairVendor_");
+
+                        Npc ammoVendor = null;
+                        if (reader["AmmoVendorId"].GetType() != typeof(DBNull))
+                            ammoVendor = ParseNpcFromQueryResult(reader, Convert.ToInt32(reader["AmmoVendorId"]), "AmmoVendor_");
+
+                        TravelPath travelPath = null;
+                        if (reader["TravelPathId"].GetType() != typeof(DBNull))
+                            travelPath = ParseTravelPathFromQueryResult(reader, Convert.ToInt32(reader["TravelPathId"]), "TravelPath_");
+
+                        hotspots.Add(new Hotspot(
+                            id,
+                            zone,
+                            description,
+                            faction,
+                            minLevel,
+                            waypoints,
+                            innkeeper,
+                            repairVendor,
+                            ammoVendor,
+                            travelPath,
+                            safeForGrinding));
+                    }
+
+                    reader.Close();
+                    db.Close();
+                }
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+            return hotspots;
+        }
+
+        static public Npc ParseNpcFromQueryResult(dynamic reader, int id, string prefix)
+        {
+            var positionX = (float)Convert.ToDecimal(reader[$"{prefix}PositionX"]);
+            var positionY = (float)Convert.ToDecimal(reader[$"{prefix}PositionY"]);
+            var positionZ = (float)Convert.ToDecimal(reader[$"{prefix}PositionZ"]);
+            var position = new Position(positionX, positionY, positionZ);
+            return new Npc(
+                id,
+                Convert.ToString(reader[$"{prefix}Name"]),
+                Convert.ToBoolean(reader[$"{prefix}IsInnkeeper"]),
+                Convert.ToBoolean(reader[$"{prefix}SellsAmmo"]),
+                Convert.ToBoolean(reader[$"{prefix}Repairs"]),
+                Convert.ToBoolean(reader[$"{prefix}Quest"]),
+                Convert.ToBoolean(reader[$"{prefix}Horde"]),
+                Convert.ToBoolean(reader[$"{prefix}Alliance"]),
+                position,
+                Convert.ToString(reader[$"{prefix}Zone"]));
+        }
+
+        static public Npc BuildStartNpc(string prefix, dynamic reader)
+        {
+            var positionX = (float)Convert.ToDecimal(reader[$"{prefix}NpcPositionX"]);
+            var positionY = (float)Convert.ToDecimal(reader[$"{prefix}NpcPositionY"]);
+            var positionZ = (float)Convert.ToDecimal(reader[$"{prefix}NpcPositionZ"]);
+            var position = new Position(positionX, positionY, positionZ);
+            return new Npc(
+                Convert.ToInt32(reader[$"{prefix}NpcId"]),
+                Convert.ToString(reader[$"{prefix}NpcName"]),
+                Convert.ToBoolean(reader[$"{prefix}NpcIsInnkeeper"]),
+                Convert.ToBoolean(reader[$"{prefix}NpcSellsAmmo"]),
+                Convert.ToBoolean(reader[$"{prefix}NpcRepairs"]),
+                Convert.ToBoolean(reader[$"{prefix}NpcQuest"]),
+                Convert.ToBoolean(reader[$"{prefix}NpcHorde"]),
+                Convert.ToBoolean(reader[$"{prefix}NpcAlliance"]),
+                position,
+                Convert.ToString(reader[$"{prefix}NpcZone"]));
+        }
+
+        static public TravelPath ParseTravelPathFromQueryResult(dynamic reader, int id, string prefix)
+        {
+            var name = Convert.ToString(reader[$"{prefix}Name"]);
+            var waypointsJson = Convert.ToString(reader[$"{prefix}Waypoints"]);
+            var waypoints = JsonConvert.DeserializeObject<Position[]>(waypointsJson);
+
+            return new TravelPath(id, name, waypoints);
+        }
+
+        public void AddBlacklistedMob(ulong guid)
+        {
+            string sql;
+            switch (databaseType)
+            {
+                case "sqlite":
+                    sql = $"INSERT INTO BlacklistedMobs (Guid) VALUES ('{guid}');";
+                    this.SqlQuery(sql);
+                    break;
+                case "mssql":
+                    sql = $"INSERT INTO BlacklistedMobs VALUES ('{guid}');";
+                    this.SqlQuery(sql);
+                    break;
+                default:
+                    // Should be unreachable if configured correctly - Code can be extended or removed for alternative storage types.
+                    throw new NotImplementedException();
+            }
+
+        }
+
+        public void RemoveBlacklistedMob(ulong guid)
+        {
+            string sql;
+            switch (databaseType)
+            {
+                case "sqlite":
+                case "mssql":
+                    sql = $"DELETE FROM BlacklistedMobs WHERE Guid = '{guid}';";
+                    this.SqlQuery(sql);
+                    break;
+                default:
+                    // Should be unreachable if configured correctly - Code can be extended or removed for alternative storage types.
+                    throw new NotImplementedException();
+            }
+        }
+
+        public List<ulong> ListBlacklistedMobs()
+        {
+            List<ulong> mobIds = new List<ulong>();
+            string sql;
+            switch (databaseType)
+            {
+                case "sqlite":
+                case "mssql":
+                    sql = $"SELECT Guid FROM BlacklistedMobs;";
+                    break;
+                default:
+                    // Should be unreachable if configured correctly - Code can be extended or removed for alternative storage types.
+                    throw new NotImplementedException();
+            }
+            if (this.IsSQL())
+            {
+                using (var db = this.NewConnection())
+                {
+                    db.Open();
+
+                    var command = this.NewCommand(sql, db);
+                    var reader = command.ExecuteReader();
+                    while (reader.Read())
+                        mobIds.Add(Convert.ToUInt64(reader["Guid"]));
+
+                    reader.Close();
+                    db.Close();
+
+                    return mobIds;
+                }
+            }
+            else
+            {
+                // Should be unreachable if configured correctly - Code can be extended or removed for alternative storage types.
+                throw new NotImplementedException();
+            }
+        }
+
+        public List<Npc> ListNPCs()
+        {
+            List<Npc> npcs = new List<Npc>();
+            string sql;
+            switch (databaseType)
+            {
+                case "sqlite":
+                case "mssql":
+                    sql = $"SELECT * FROM Npcs;";
+                    break;
+                default:
+                    // Should be unreachable if configured correctly - Code can be extended or removed for alternative storage types.
+                    throw new NotImplementedException();
+            }
+
+            if (this.IsSQL())
+            {
+                using (var db = this.NewConnection())
+                {
+                    db.Open();
+
+                    var command = this.NewCommand(sql, db);
+                    var reader = command.ExecuteReader();
+                    while (reader.Read())
+                    {
+                        var positionX = (float)Convert.ToDecimal(reader["PositionX"]);
+                        var positionY = (float)Convert.ToDecimal(reader["PositionY"]);
+                        var positionZ = (float)Convert.ToDecimal(reader["PositionZ"]);
+                        npcs.Add(new Npc(
+                            Convert.ToInt32(reader["Id"]),
+                            Convert.ToString(reader["Name"]),
+                            Convert.ToBoolean(reader["IsInnkeeper"]),
+                            Convert.ToBoolean(reader["SellsAmmo"]),
+                            Convert.ToBoolean(reader["Repairs"]),
+                            Convert.ToBoolean(reader["Quest"]),
+                            Convert.ToBoolean(reader["Horde"]),
+                            Convert.ToBoolean(reader["Alliance"]),
+                            new Position(positionX, positionY, positionZ),
+                            Convert.ToString(reader["Zone"])));
+                    }
+
+                    reader.Close();
+                    db.Close();
+
+                    return npcs;
+                }
+            }
+            else
+            {
+                // Should be unreachable if configured correctly - Code can be extended or removed for alternative storage types.
+                throw new NotImplementedException();
+            }
+        }
+
+        public IList<CommandModel> GetCommandsForPlayer(string playerName)
+        {
+            string sql;
+            IList<CommandModel> commands = new List<CommandModel>();
+            switch (databaseType)
+            {
+                case "sqlite":
+                case "mssql":
+                    sql = $"SELECT * FROM Commands WHERE Player = '{playerName}'";
+                    break;
+                default:
+                    // Should be unreachable if configured correctly - Code can be extended or removed for alternative storage types.
+                    throw new NotImplementedException();
+            }
+
+            if (this.IsSQL())
+            {
+                using (var db = this.NewConnection())
+                {
+                    db.Open();
+
+                    var command = this.NewCommand(sql, db);
+                    var reader = command.ExecuteReader();
+                    while (reader.Read())
+                    {
+                        commands.Add(new CommandModel(
+                            Convert.ToInt32(reader["Id"]),
+                            Convert.ToString(reader["Command"]),
+                            Convert.ToString(reader["Player"]),
+                            Convert.ToString(reader["Args"])));
+                    }
+
+                    reader.Close();
+                    db.Close();
+
+                    return commands;
+                }
+            }
+            else
+            {
+                // Should be unreachable if configured correctly - Code can be extended or removed for alternative storage types.
+                throw new NotImplementedException();
+            }
+        }
+        public void DeleteCommand(int id)
+        {
+            string sql;
+            switch (databaseType)
+            {
+                case "sqlite":
+                case "mssql":
+                    sql = $"DELETE FROM Commands WHERE Id = {id}";
+                    break;
+                default:
+                    // Should be unreachable if configured correctly - Code can be extended or removed for alternative storage types.
+                    throw new NotImplementedException();
+            }
+
+            if (this.IsSQL())
+            {
+                using (var db = this.NewConnection())
+                {
+                    db.Open();
+
+                    var command = this.NewCommand(sql, db);
+                    command.ExecuteNonQuery();
+
+                    db.Close();
+                }
+            }
+            else
+            {
+                // Should be unreachable if configured correctly - Code can be extended or removed for alternative storage types.
+                throw new NotImplementedException();
+            }
+        }
+
+        public void DeleteCommandsForPlayer(string player)
+        {
+            string sql;
+            switch (databaseType)
+            {
+                case "sqlite":
+                case "mssql":
+                    sql = $"DELETE FROM Commands WHERE Player = '{player}'";
+                    break;
+                default:
+                    // Should be unreachable if configured correctly - Code can be extended or removed for alternative storage types.
+                    throw new NotImplementedException();
+            }
+
+            if (this.IsSQL())
+            {
+                using (var db = this.NewConnection())
+                {
+                    db.Open();
+
+                    var command = this.NewCommand(sql, db);
+                    command.ExecuteNonQuery();
+
+                    db.Close();
+                }
+            }
+            else
+            {
+                // Should be unreachable if configured correctly - Code can be extended or removed for alternative storage types.
+                throw new NotImplementedException();
+            }
+        }
+
+
+        public ReportSummary GetLatestReportSignatures()
+        {
+            string sql;
+            switch (databaseType)
+            {
+                case "sqlite":
+                    sql = $"SELECT Id FROM Commands WHERE Command = '!report' ORDER BY Id DESC LIMIT 1";
+                    break;
+                case "mssql":
+                    sql = $"SELECT TOP 1 Id FROM Commands WHERE Command = '!report' ORDER BY Id DESC";
+                    break;
+                default:
+                    // Should be unreachable if configured correctly - Code can be extended or removed for alternative storage types.
+                    throw new NotImplementedException();
+            }
+
+            if (this.IsSQL())
+            {
+                using (var db = this.NewConnection())
+                {
+                    var reportSignatures = new List<ReportSignature>();
+
+                    db.Open();
+
+                    var command1 = this.NewCommand(sql, db);
+                    var reader1 = command1.ExecuteReader();
+
+                    var commandId = -1;
+
+                    if (reader1.Read())
+                        commandId = Convert.ToInt32(reader1["Id"]);
+
+                    reader1.Close();
+
+                    if (commandId != -1)
+                    {
+                        var sql2 = $"SELECT * FROM ReportSignatures s WHERE s.CommandId = {commandId}";
+                        var command2 = this.NewCommand(sql2, db);
+                        var reader2 = command2.ExecuteReader();
+
+                        while (reader2.Read())
+                        {
+                            reportSignatures.Add(new ReportSignature(
+                                Convert.ToInt32(reader2["Id"]),
+                                Convert.ToString(reader2["Player"]),
+                                Convert.ToInt32(reader2["CommandId"])));
+                        }
+
+                        reader2.Close();
+                    }
+
+                    db.Close();
+                    return new ReportSummary(commandId, reportSignatures);
+                }
+            }
+            else
+            {
+                // Should be unreachable if configured correctly - Code can be extended or removed for alternative storage types.
+                throw new NotImplementedException();
+            }
+        }
+
+        public void AddReportSignature(string playerName, int commandId)
+        {
+            string sql;
+            switch (databaseType)
+            {
+                case "sqlite":
+                    sql = $"INSERT INTO ReportSignatures (Player, CommandId) VALUES ('{playerName}', {commandId})";
+                    break;
+                case "mssql":
+                    sql = $"INSERT INTO ReportSignatures VALUES ('{playerName}', {commandId})";
+                    break;
+                default:
+                    // Should be unreachable if configured correctly - Code can be extended or removed for alternative storage types.
+                    throw new NotImplementedException();
+            }
+
+            if (this.IsSQL())
+            {
+                using (var db = this.NewConnection())
+                {
+                    db.Open();
+                    var command = this.NewCommand(sql, db);
+                    command.ExecuteNonQuery();
+                    db.Close();
+                }
+            }
+            else
+            {
+                // Should be unreachable if configured correctly - Code can be extended or removed for alternative storage types.
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/BloogBot/DiscordClientWrapper.cs
+++ b/BloogBot/DiscordClientWrapper.cs
@@ -14,35 +14,41 @@ namespace BloogBot
         static SocketGuild guild;
         static SocketRole botsmithsRole;
         static SocketTextChannel channel;
-
+        
         static ulong bloogsMinionsGuildId;
         static ulong botsmithsRoleId;
         static ulong bloogBotChannelId;
 
+        static bool discordBotEnabled;
+
         static internal void Initialize(BotSettings botSettings)
         {
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+            discordBotEnabled = botSettings.DiscordBotEnabled;
+            if (discordBotEnabled)
+            { 
+                ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-            bloogsMinionsGuildId = Convert.ToUInt64(botSettings.DiscordGuildId);
-            botsmithsRoleId = Convert.ToUInt64(botSettings.DiscordGuildId);
-            bloogBotChannelId = Convert.ToUInt64(botSettings.DiscordChannelId);
-            client = new DiscordSocketClient();
+                bloogsMinionsGuildId = Convert.ToUInt64(botSettings.DiscordGuildId);
+                botsmithsRoleId = Convert.ToUInt64(botSettings.DiscordGuildId);
+                bloogBotChannelId = Convert.ToUInt64(botSettings.DiscordChannelId);
+                client = new DiscordSocketClient();
 
-            client.Log += Log;
-            client.Ready += ClientReady;
+                client.Log += Log;
+                client.Ready += ClientReady;
 
-            Task.Run(async () =>
-            {
-                try
+                Task.Run(async () =>
                 {
-                    await client.LoginAsync(TokenType.Bot, botSettings.DiscordBotToken);
-                    await client.StartAsync();
-                }
-                catch (Exception e)
-                {
-                    Console.WriteLine($"Discord connection failed with exception: {e}");
-                }
-            });
+                    try
+                    {
+                        await client.LoginAsync(TokenType.Bot, botSettings.DiscordBotToken);
+                        await client.StartAsync();
+                    }
+                    catch (Exception e)
+                    {
+                        Console.WriteLine($"Discord connection failed with exception: {e}");
+                    }
+                });
+            }
         }
 
         static Task Log(LogMessage msg)
@@ -62,35 +68,41 @@ namespace BloogBot
 
         static internal void KillswitchAlert(string playerName)
         {
-            Task.Run(async () => 
+            if (discordBotEnabled)
+                Task.Run(async () => 
                 await channel.SendMessageAsync($"{botsmithsRole.Mention} \uD83D\uDEA8 ALERT ALERT! {playerName} has arrived in GM Island! Stopping for now. \uD83D\uDEA8")
             );
         }
 
         static internal void TeleportAlert(string playerName)
         {
-            Task.Run(async () => 
+            if (discordBotEnabled)
+                Task.Run(async () => 
                 await channel.SendMessageAsync($"{botsmithsRole.Mention} \uD83D\uDEA8 ALERT ALERT! {playerName} has been teleported! Stopping for now. \uD83D\uDEA8")
             );
         }
 
         static public void SendMessage(string message)
         {
-            Task.Run(async () => 
+            if (discordBotEnabled)
+                Task.Run(async () => 
                 await channel.SendMessageAsync(message)
             );
         }
 
         static public void SendItemNotification(string playerName, ItemQuality quality, int itemId)
         {
-            var sb = new StringBuilder();
-            var article = quality == ItemQuality.Rare ? "a" : "an";
-            sb.Append($"{playerName} here! I just found {article} {quality} item!\n");
-            sb.Append($"https://classic.wowhead.com/item={itemId}");
+            if (discordBotEnabled)
+            {
+                var sb = new StringBuilder();
+                var article = quality == ItemQuality.Rare ? "a" : "an";
+                sb.Append($"{playerName} here! I just found {article} {quality} item!\n");
+                sb.Append($"https://classic.wowhead.com/item={itemId}");
 
-            Task.Run(async () => 
-                await channel.SendMessageAsync(sb.ToString())
-            );
+                Task.Run(async () =>
+                    await channel.SendMessageAsync(sb.ToString())
+                );
+            }
         }
     }
 }

--- a/BloogBot/Game/Objects/WoWUnit.cs
+++ b/BloogBot/Game/Objects/WoWUnit.cs
@@ -64,6 +64,8 @@ namespace BloogBot.Game.Objects
 
         public bool CanBeLooted => Health == 0 && DynamicFlags.HasFlag(DynamicFlags.CanBeLooted);
 
+        public bool CanBeSkinned => Health == 0 && UnitFlags.HasFlag(UnitFlags.UNIT_FLAG_SKINNABLE);
+
         public bool TappedByOther => DynamicFlags.HasFlag(DynamicFlags.Tapped) && !DynamicFlags.HasFlag(DynamicFlags.TappedByMe);
 
         public UnitFlags UnitFlags => (UnitFlags)MemoryManager.ReadInt(GetDescriptorPtr() + MemoryAddresses.WoWUnit_UnitFlagsOffset);

--- a/BloogBot/Repository.cs
+++ b/BloogBot/Repository.cs
@@ -4,16 +4,16 @@ using System;
 using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Globalization;
+using static BloogBot.DatabaseWrapper;
 
 namespace BloogBot
 {
     static public class Repository
     {
-        static string connectionString;
-
-        static internal void Initialize(string parConnectionString)
+        static DatabaseWrapper databaseWrapper;
+        static internal void Initialize(string databaseType, string parConnectionString)
         {
-            connectionString = parConnectionString;
+            databaseWrapper = new DatabaseWrapper(databaseType, parConnectionString);
             CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
         }
 
@@ -33,72 +33,28 @@ namespace BloogBot
             var encodedName = Encode(name);
             var encodedZone = Encode(zone);
 
-            using (var db = new SqlConnection(connectionString))
-            {
-                db.Open();
-
-                // first insert
-                var sql = $"INSERT INTO Npcs VALUES ('{encodedName}', {Convert.ToInt32(isInnkeeper)}, {Convert.ToInt32(sellsAmmo)}, {Convert.ToInt32(repairs)}, {Convert.ToInt32(quest)}, {Convert.ToInt32(horde)}, {Convert.ToInt32(alliance)}, {positionX}, {positionY}, {positionZ}, '{encodedZone}');";
-                var command = new SqlCommand(sql, db);
-                command.ExecuteNonQuery();
-
-                // then retrieve it so we have the id
-                sql = $"SELECT TOP 1 * FROM Npcs WHERE Name = '{encodedName}';";
-                command = new SqlCommand(sql, db);
-                var reader = command.ExecuteReader();
-                reader.Read();
-
-                var id = Convert.ToInt32(reader["Id"]);
-                var npc = new Npc(id,
-                    name,
-                    isInnkeeper,
-                    sellsAmmo,
-                    repairs,
-                    quest,
-                    horde,
-                    alliance,
-                    new Position(positionX, positionY, positionZ),
-                    zone);
-
-                reader.Close();
-                db.Close();
-
-                return npc;
-            }
+            return databaseWrapper.AddNpc(encodedName,
+             isInnkeeper,
+             sellsAmmo,
+             repairs,
+             quest,
+             horde,
+             alliance,
+             positionX,
+             positionY,
+             positionZ,
+             encodedZone);
         }
 
         static public bool NpcExists(string name)
         {
             var encodedName = Encode(name);
-
-            using (var db = new SqlConnection(connectionString))
-            {
-                db.Open();
-
-                var sql = $"SELECT TOP 1 Id FROM Npcs WHERE Name = '{encodedName}';";
-                var command = new SqlCommand(sql, db);
-                var exists = command.ExecuteReader().HasRows;
-
-                db.Close();
-
-                return exists;
-            }
+            return databaseWrapper.NpcExists(encodedName);
         }
 
         static public bool BlacklistedMobExists(ulong guid)
         {
-            using (var db = new SqlConnection(connectionString))
-            {
-                db.Open();
-
-                var sql = $"SELECT TOP 1 Id FROM BlacklistedMobs WHERE Guid = '{guid}';";
-                var command = new SqlCommand(sql, db);
-                var exists = command.ExecuteReader().HasRows;
-
-                db.Close();
-
-                return exists;
-            }
+            return databaseWrapper.BlacklistedMobExists(guid);
         }
 
         static public TravelPath AddTravelPath(string name, Position[] waypoints)
@@ -107,75 +63,18 @@ namespace BloogBot
 
             var waypointsJson = JsonConvert.SerializeObject(waypoints);
 
-            using (var db = new SqlConnection(connectionString))
-            {
-                db.Open();
+            return databaseWrapper.AddTravelPath(encodedName, waypointsJson);
 
-                // first insert
-                var sql = $"INSERT INTO TravelPaths VALUES ('{encodedName}', '{waypointsJson}');";
-                var command = new SqlCommand(sql, db);
-                command.Prepare();
-                command.ExecuteNonQuery();
-
-                // then retrieve it so we have the id
-                sql = $"SELECT TOP 1 * FROM TravelPaths WHERE Name = '{encodedName}';";
-                command = new SqlCommand(sql, db);
-                var reader = command.ExecuteReader();
-                reader.Read();
-
-                var id = Convert.ToInt32(reader["Id"]);
-                var travelPath = new TravelPath(id, name, waypoints);
-
-                reader.Close();
-                db.Close();
-
-                return travelPath;
-            }
         }
 
         static public IEnumerable<TravelPath> ListTravelPaths()
         {
-            var travelPaths = new List<TravelPath>();
-
-            using (var db = new SqlConnection(connectionString))
-            {
-                db.Open();
-
-                var sql = "SELECT * FROM TravelPaths ORDER BY Name;";
-                var command = new SqlCommand(sql, db);
-                var reader = command.ExecuteReader();
-                while (reader.Read())
-                {
-                    var id = Convert.ToInt32(reader["Id"]);
-                    var name = Convert.ToString(reader["Name"]);
-                    var waypointsJson = Convert.ToString(reader["Waypoints"]);
-                    var waypoints = JsonConvert.DeserializeObject<Position[]>(waypointsJson);
-                    travelPaths.Add(new TravelPath(id, name, waypoints));
-                }
-
-                reader.Close();
-                db.Close();
-
-                return travelPaths;
-            }
+            return databaseWrapper.ListTravelPaths();
         }
 
         static public bool TravelPathExists(string name)
         {
-            var encodedName = Encode(name);
-
-            using (var db = new SqlConnection(connectionString))
-            {
-                db.Open();
-
-                var sql = $"SELECT TOP 1 Id FROM TravelPaths WHERE Name = '{encodedName}'";
-                var command = new SqlCommand(sql, db);
-                var exists = command.ExecuteReader().HasRows;
-
-                db.Close();
-
-                return exists;
-            }
+            return databaseWrapper.TravelPathExists(name);
         }
 
         static public Hotspot AddHotspot(
@@ -193,353 +92,71 @@ namespace BloogBot
             var encodedZone = Encode(zone);
             var encodedDescription = Encode(description);
             var encodedFaction = Encode(faction);
-            
+
             var waypointsJson = JsonConvert.SerializeObject(waypoints);
-
-            using (var db = new SqlConnection(connectionString))
-            {
-                db.Open();
-
-                // first insert
-                var sql = $"INSERT INTO Hotspots VALUES ('{encodedZone}', '{encodedDescription}', '{encodedFaction}', '{waypointsJson}', {innkeeper?.Id.ToString() ?? "NULL"}, {repairVendor?.Id.ToString() ?? "NULL"}, {ammoVendor?.Id.ToString() ?? "NULL"}, {minLevel}, {travelPath?.Id.ToString() ?? "NULL"}, {Convert.ToInt32(safeForGrinding)});";
-                var command = new SqlCommand(sql, db);
-                command.ExecuteNonQuery();
-
-                // then retrieve it so we have the id
-                sql = $"SELECT TOP 1 * FROM Hotspots WHERE Description = '{encodedDescription}';";
-                command = new SqlCommand(sql, db);
-                var reader = command.ExecuteReader();
-                reader.Read();
-
-                var id = Convert.ToInt32(reader["Id"]);
-                var hotspot = new Hotspot(
-                    id,
-                    zone,
-                    description,
-                    faction,
-                    minLevel,
-                    waypoints,
-                    innkeeper,
-                    repairVendor,
-                    ammoVendor,
-                    travelPath,
-                    safeForGrinding);
-
-                reader.Close();
-                db.Close();
-
-                return hotspot;
-            }
+            return databaseWrapper.AddHotspot(description, zone, faction, waypointsJson, innkeeper, repairVendor, ammoVendor, minLevel, travelPath, safeForGrinding, waypoints);
         }
 
         static public IEnumerable<Hotspot> ListHotspots()
         {
             var hotspots = new List<Hotspot>();
-
-            using (var db = new SqlConnection(connectionString))
-            {
-                db.Open();
-
-                var sql = @"
-                    SELECT
-	                    h.Zone, h.Description, h.Faction, h.Waypoints, h.InnkeeperId, h.RepairVendorId, h.AmmoVendorId, h.MinimumLevel, h.TravelPathId, h.SafeForGrinding, h.Id,
-	                    i.Name as Innkeeper_Name, i.IsInnkeeper as Innkeeper_IsInnkeeper, i.SellsAmmo as Innkeeper_SellsAmmo, i.Repairs as Innkeeper_Repairs, i.Quest as Innkeeper_Quest, i.Horde as Innkeeper_Horde, i.Alliance as Innkeeper_Alliance, i.PositionX as Innkeeper_PositionX, i.PositionY as Innkeeper_PositionY, i.PositionZ as Innkeeper_PositionZ, i.Zone as Innkeeper_Zone, i.Id as Innkeeper_Id,
-	                    a.Name as AmmoVendor_Name, a.IsInnkeeper as AmmoVendor_IsInnkeeper, a.SellsAmmo as AmmoVendor_SellsAmmo, a.Repairs as AmmoVendor_Repairs, a.Quest as AmmoVendor_Quest, a.Horde as AmmoVendor_Horde, a.Alliance as AmmoVendor_Alliance, a.PositionX as AmmoVendor_PositionX, a.PositionY as AmmoVendor_PositionY, a.PositionZ as AmmoVendor_PositionZ, a.Zone as AmmoVendor_Zone, a.Id as AmmoVendor_Id,
-	                    r.Name as RepairVendor_Name, r.IsInnkeeper as RepairVendor_IsInnkeeper, r.SellsAmmo as RepairVendor_SellsAmmo, r.Repairs as RepairVendor_Repairs, r.Quest as RepairVendor_Quest, r.Horde as RepairVendor_Horde, r.Alliance as RepairVendor_Alliance, r.PositionX as RepairVendor_PositionX, r.PositionY as RepairVendor_PositionY, r.PositionZ as RepairVendor_PositionZ, r.Zone as RepairVendor_Zone, r.Id as RepairVendor_Id,
-                        t.Name as TravelPath_Name, t.Waypoints as TravelPath_Waypoints, t.Id as TravelPath_Id
-                    FROM Hotspots h
-	                    LEFT JOIN Npcs i ON h.InnkeeperId = i.Id
-	                    LEFT JOIN Npcs a ON h.AmmoVendorId = a.Id
-	                    LEFT JOIN Npcs r ON h.RepairVendorId = r.Id
-                        LEFT JOIN TravelPaths t ON h.TravelPathId = t.Id";
-
-                var command = new SqlCommand(sql, db);
-                var reader = command.ExecuteReader();
-                while (reader.Read())
-                {
-                    var id = Convert.ToInt32(reader["Id"]);
-                    var zone = Convert.ToString(reader["Zone"]);
-                    var description = Convert.ToString(reader["Description"]);
-                    var faction = Convert.ToString(reader["Faction"]);
-                    var minLevel = Convert.ToInt32(reader["MinimumLevel"]);
-                    var waypointsJson = Convert.ToString(reader["Waypoints"]);
-                    var waypoints = JsonConvert.DeserializeObject<Position[]>(waypointsJson);
-                    var safeForGrinding = Convert.ToBoolean(reader["SafeForGrinding"]);
-
-                    Npc innkeeper = null;
-                    if (reader["InnkeeperId"].GetType() != typeof(DBNull))
-                        innkeeper = ParseNpcFromQueryResult(reader, Convert.ToInt32(reader["InnkeeperId"]), "Innkeeper_");
-
-                    Npc repairVendor = null;
-                    if (reader["RepairVendorId"].GetType() != typeof(DBNull))
-                        repairVendor = ParseNpcFromQueryResult(reader, Convert.ToInt32(reader["RepairVendorId"]), "RepairVendor_");
-
-                    Npc ammoVendor = null;
-                    if (reader["AmmoVendorId"].GetType() != typeof(DBNull))
-                        ammoVendor = ParseNpcFromQueryResult(reader, Convert.ToInt32(reader["AmmoVendorId"]), "AmmoVendor_");
-
-                    TravelPath travelPath = null;
-                    if (reader["TravelPathId"].GetType() != typeof(DBNull))
-                        travelPath = ParseTravelPathFromQueryResult(reader, Convert.ToInt32(reader["TravelPathId"]), "TravelPath_");
-
-                    hotspots.Add(new Hotspot(
-                        id,
-                        zone,
-                        description,
-                        faction,
-                        minLevel,
-                        waypoints,
-                        innkeeper,
-                        repairVendor,
-                        ammoVendor,
-                        travelPath,
-                        safeForGrinding));
-                }
-
-                reader.Close();
-                db.Close();
-
-                return hotspots;
-            }
+            hotspots = databaseWrapper.ListHotspots();
+            return hotspots;
         }
 
-        static public Npc ParseNpcFromQueryResult(SqlDataReader reader, int id, string prefix)
-        {
-            var positionX = (float)Convert.ToDecimal(reader[$"{prefix}PositionX"]);
-            var positionY = (float)Convert.ToDecimal(reader[$"{prefix}PositionY"]);
-            var positionZ = (float)Convert.ToDecimal(reader[$"{prefix}PositionZ"]);
-            var position = new Position(positionX, positionY, positionZ);
-            return new Npc(
-                id,
-                Convert.ToString(reader[$"{prefix}Name"]),
-                Convert.ToBoolean(reader[$"{prefix}IsInnkeeper"]),
-                Convert.ToBoolean(reader[$"{prefix}SellsAmmo"]),
-                Convert.ToBoolean(reader[$"{prefix}Repairs"]),
-                Convert.ToBoolean(reader[$"{prefix}Quest"]),
-                Convert.ToBoolean(reader[$"{prefix}Horde"]),
-                Convert.ToBoolean(reader[$"{prefix}Alliance"]),
-                position,
-                Convert.ToString(reader[$"{prefix}Zone"]));
-        }
 
-        static public Npc BuildStartNpc(string prefix, SqlDataReader reader)
-        {
-            var positionX = (float)Convert.ToDecimal(reader[$"{prefix}NpcPositionX"]);
-            var positionY = (float)Convert.ToDecimal(reader[$"{prefix}NpcPositionY"]);
-            var positionZ = (float)Convert.ToDecimal(reader[$"{prefix}NpcPositionZ"]);
-            var position = new Position(positionX, positionY, positionZ);
-            return new Npc(
-                Convert.ToInt32(reader[$"{prefix}NpcId"]),
-                Convert.ToString(reader[$"{prefix}NpcName"]),
-                Convert.ToBoolean(reader[$"{prefix}NpcIsInnkeeper"]),
-                Convert.ToBoolean(reader[$"{prefix}NpcSellsAmmo"]),
-                Convert.ToBoolean(reader[$"{prefix}NpcRepairs"]),
-                Convert.ToBoolean(reader[$"{prefix}NpcQuest"]),
-                Convert.ToBoolean(reader[$"{prefix}NpcHorde"]),
-                Convert.ToBoolean(reader[$"{prefix}NpcAlliance"]),
-                position,
-                Convert.ToString(reader[$"{prefix}NpcZone"]));
-        }
-
-        static public TravelPath ParseTravelPathFromQueryResult(SqlDataReader reader, int id, string prefix)
-        {
-            var name = Convert.ToString(reader[$"{prefix}Name"]);
-            var waypointsJson = Convert.ToString(reader[$"{prefix}Waypoints"]);
-            var waypoints = JsonConvert.DeserializeObject<Position[]>(waypointsJson);
-
-            return new TravelPath(id, name, waypoints);
-        }
 
         static public void AddBlacklistedMob(ulong guid)
         {
-            using (var db = new SqlConnection(connectionString))
-            {
-                db.Open();
-
-                var sql = $"INSERT INTO BlacklistedMobs VALUES ('{guid}');";
-                var command = new SqlCommand(sql, db);
-                command.ExecuteNonQuery();
-
-                db.Close();
-            }
-        }
-
-        static public void RemoveBlacklistedMob(ulong guid)
-        {
-            using (var db = new SqlConnection(connectionString))
-            {
-                db.Open();
-
-                var sql = $"DELETE FROM BlacklistedMobs WHERE Guid = '{guid}';";
-                var command = new SqlCommand(sql, db);
-                command.ExecuteNonQuery();
-
-                db.Close();
-            }
+            databaseWrapper.AddBlacklistedMob(guid);
         }
 
         static public IList<ulong> ListBlacklistedMobIds()
         {
-            IList<ulong> mobIds = new List<ulong>();
-
-            using (var db = new SqlConnection(connectionString))
-            {
-                db.Open();
-
-                var sql = $"SELECT Guid FROM BlacklistedMobs;";
-                var command = new SqlCommand(sql, db);
-                var reader = command.ExecuteReader();
-                while (reader.Read())
-                    mobIds.Add(Convert.ToUInt64(reader["Guid"]));
-
-                reader.Close();
-                db.Close();
-
-                return mobIds;
-            }
+            return databaseWrapper.ListBlacklistedMobs();
         }
+
+        static public void RemoveBlacklistedMob(ulong guid)
+        {
+            databaseWrapper.RemoveBlacklistedMob(guid);
+        }
+
 
         static public IList<Npc> ListNpcs()
         {
-            IList<Npc> npcs = new List<Npc>();
-
-            using (var db = new SqlConnection(connectionString))
-            {
-                db.Open();
-
-                var sql = $"SELECT * FROM Npcs;";
-                var command = new SqlCommand(sql, db);
-                var reader = command.ExecuteReader();
-                while (reader.Read())
-                {
-                    var positionX = (float)Convert.ToDecimal(reader["PositionX"]);
-                    var positionY = (float)Convert.ToDecimal(reader["PositionY"]);
-                    var positionZ = (float)Convert.ToDecimal(reader["PositionZ"]);
-                    npcs.Add(new Npc(
-                        Convert.ToInt32(reader["Id"]),
-                        Convert.ToString(reader["Name"]),
-                        Convert.ToBoolean(reader["IsInnkeeper"]),
-                        Convert.ToBoolean(reader["SellsAmmo"]),
-                        Convert.ToBoolean(reader["Repairs"]),
-                        Convert.ToBoolean(reader["Quest"]),
-                        Convert.ToBoolean(reader["Horde"]),
-                        Convert.ToBoolean(reader["Alliance"]),
-                        new Position(positionX, positionY, positionZ),
-                        Convert.ToString(reader["Zone"])));
-                }
-
-                reader.Close();
-                db.Close();
-
-                return npcs;
-            }
+            return databaseWrapper.ListNPCs();
         }
+
+        //HERE
 
         static public IList<CommandModel> GetCommandsForPlayer(string playerName)
         {
-            IList<CommandModel> commands = new List<CommandModel>();
-
-            using (var db = new SqlConnection(connectionString))
-            {
-                db.Open();
-
-                var sql = $"SELECT * FROM Commands WHERE Player = '{playerName}'";
-                var command = new SqlCommand(sql, db);
-                var reader = command.ExecuteReader();
-                while (reader.Read())
-                {
-                    commands.Add(new CommandModel(
-                        Convert.ToInt32(reader["Id"]),
-                        Convert.ToString(reader["Command"]),
-                        Convert.ToString(reader["Player"]),
-                        Convert.ToString(reader["Args"])));
-                }
-
-                reader.Close();
-                db.Close();
-
-                return commands;
-            }
+            return databaseWrapper.GetCommandsForPlayer(playerName);
         }
 
         static public void DeleteCommand(int id)
         {
-            using (var db = new SqlConnection(connectionString))
-            {
-                db.Open();
-
-                var sql = $"DELETE FROM Commands WHERE Id = {id}";
-                var command = new SqlCommand(sql, db);
-                command.ExecuteNonQuery();
-
-                db.Close();
-            }
+            databaseWrapper.DeleteCommand(id);
         }
 
         static public void DeleteCommandsForPlayer(string player)
         {
-            using (var db = new SqlConnection(connectionString))
-            {
-                db.Open();
-
-                var sql = $"DELETE FROM Commands WHERE Player = '{player}'";
-                var command = new SqlCommand(sql, db);
-                command.ExecuteNonQuery();
-
-                db.Close();
-            }
+            databaseWrapper.DeleteCommandsForPlayer(player);
         }
 
         static public ReportSummary GetLatestReportSignatures()
         {
-            using (var db = new SqlConnection(connectionString))
-            {
-                var reportSignatures = new List<ReportSignature>();
-
-                db.Open();
-
-                var sql1 = "SELECT TOP 1 Id FROM Commands WHERE Command = '!report' ORDER BY Id DESC";
-                var command1 = new SqlCommand(sql1, db);
-                var reader1 = command1.ExecuteReader();
-
-                var commandId = -1;
-
-                if (reader1.Read())
-                    commandId = Convert.ToInt32(reader1["Id"]);
-
-                reader1.Close();
-
-                if (commandId != -1)
-                {
-                    var sql2 = $"SELECT * FROM ReportSignatures s WHERE s.CommandId = {commandId}";
-                    var command2 = new SqlCommand(sql2, db);
-                    var reader2 = command2.ExecuteReader();
-
-                    while (reader2.Read())
-                    {
-                        reportSignatures.Add(new ReportSignature(
-                            Convert.ToInt32(reader2["Id"]),
-                            Convert.ToString(reader2["Player"]),
-                            Convert.ToInt32(reader2["CommandId"])));
-                    }
-
-                    reader2.Close();
-                }
-
-                db.Close();
-
-                return new ReportSummary(commandId, reportSignatures);
-            }
+            return databaseWrapper.GetLatestReportSignatures();
         }
 
         static public void AddReportSignature(string playerName, int commandId)
         {
-            using (var db = new SqlConnection(connectionString))
+            using (var db = databaseWrapper.NewConnection())
             {
                 db.Open();
 
                 var sql = $"INSERT INTO ReportSignatures VALUES ('{playerName}', {commandId})";
-                var command = new SqlCommand(sql, db);
+                var command = databaseWrapper.NewCommand(sql, db);
                 command.ExecuteNonQuery();
 
                 db.Close();

--- a/BloogBot/SqliteSchema.SQL
+++ b/BloogBot/SqliteSchema.SQL
@@ -1,0 +1,123 @@
+CREATE TABLE IF NOT EXISTS [main].[BlacklistedMobs](
+	[Guid] [text] NOT NULL,
+	[Id] [integer] PRIMARY KEY AUTOINCREMENT NOT NULL
+);
+ 
+CREATE TABLE IF NOT EXISTS [main].[Commands](
+	[Id] [integer] PRIMARY KEY AUTOINCREMENT NOT NULL,
+	[Command] [text] NOT NULL,
+	[Player] [text] NOT NULL,
+	[Args] [text] NULL
+);
+
+CREATE TABLE IF NOT EXISTS [main].[Hotspots](
+	[Zone] [text] NOT NULL,
+	[Description] [text] NOT NULL,
+	[Faction] [text] NOT NULL,
+	[Waypoints] [text] NOT NULL,
+	[InnkeeperId] [int] NULL,
+	[RepairVendorId] [int] NULL,
+	[AmmoVendorId] [int] NULL,
+	[MinimumLevel] [int] NOT NULL,
+	[TravelPathId] [int] NULL,
+	[SafeForGrinding] [int] NOT NULL,
+	[Id] [integer] PRIMARY KEY AUTOINCREMENT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS [main].[HotspotsV2](
+	[Id] [integer] PRIMARY KEY AUTOINCREMENT NOT NULL,
+	[Polyn] [text] NOT NULL,
+	[Zone] [text] NOT NULL,
+	[Description] [text] NOT NULL,
+	[Faction] [text] NOT NULL,
+	[MinimumLevel] [int] NOT NULL,
+	[TravelPathId] [int] NULL,
+	[TownId] [int] NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS [main].[Kills](
+	[PlayerLevel] [int] NOT NULL,
+	[PlayerName] [text] NOT NULL,
+	[PlayerClass] [text] NOT NULL,
+	[EnemyName] [text] NOT NULL,
+	[EnemyLevel] [int] NOT NULL,
+	[EnemyType] [text] NOT NULL,
+	[HealthPercentLost] [int] NOT NULL,
+	[CombatDuration] [int] NOT NULL,
+	[Id] [integer] PRIMARY KEY AUTOINCREMENT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS [main].[Npcs](
+	[Name] [text] NOT NULL,
+	[IsInnkeeper] [bit] NOT NULL,
+	[SellsAmmo] [bit] NOT NULL,
+	[Repairs] [bit] NOT NULL,
+	[Quest] [bit] NOT NULL,
+	[Horde] [bit] NOT NULL,
+	[Alliance] [bit] NOT NULL,
+	[PositionX] [numeric](18, 0) NOT NULL,
+	[PositionY] [numeric](18, 0) NOT NULL,
+	[PositionZ] [numeric](18, 0) NOT NULL,
+	[Zone] [text] NOT NULL,
+	[Id] [integer] PRIMARY KEY AUTOINCREMENT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS [main].[QuestCompletions](
+	[PlayerGuid] [text] NOT NULL,
+	[QuestId] [int] NOT NULL,
+	[Id] [integer] PRIMARY KEY AUTOINCREMENT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS [main].[QuestHubs](
+	[Name] [text] NOT NULL,
+	[Id] [integer] PRIMARY KEY AUTOINCREMENT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS [main].[QuestObjectives](
+	[Type] [text] NOT NULL,
+	[Name] [text] NOT NULL,
+	[Source] [text] NOT NULL,
+	[Quantity] [int] NOT NULL,
+	[QuestId] [int] NOT NULL,
+	[ObjectId] [int] NOT NULL,
+	[Id] [integer] PRIMARY KEY AUTOINCREMENT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS [main].[QuestPrerequisites](
+	[ParentId] [int] NOT NULL,
+	[ChildId] [int] NOT NULL,
+	[Id] [integer] PRIMARY KEY AUTOINCREMENT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS [main].[Quests](
+	[Name] [text] NOT NULL,
+	[QuestHubId] [int] NOT NULL,
+	[HotspotId] [int] NULL,
+	[StartNpcId] [int] NOT NULL,
+	[EndNpcId] [int] NOT NULL,
+	[RequiredLevel] [int] NOT NULL,
+	[Class] [text] NOT NULL,
+	[QuestId] [int] NOT NULL,
+	[Id] [integer] PRIMARY KEY AUTOINCREMENT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS [main].[ReportSignatures](
+	[Id] [integer] PRIMARY KEY AUTOINCREMENT NOT NULL,
+	[Player] [text] NOT NULL,
+	[CommandId] [int] NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS [main].[Towns](
+	[Id] [integer] PRIMARY KEY AUTOINCREMENT NOT NULL,
+	[InnkeeperId] [int] NULL,
+	[RepairVendorId] [int] NULL,
+	[AmmoVendorId] [int] NULL,
+	[Name] [text] NULL
+);
+
+CREATE TABLE IF NOT EXISTS [main].[TravelPaths](
+	[Name] [text] NOT NULL,
+	[Waypoints] [text] NOT NULL,
+	[Id] [integer] PRIMARY KEY AUTOINCREMENT NOT NULL
+);
+

--- a/BloogBot/TSqlSchema.SQL
+++ b/BloogBot/TSqlSchema.SQL
@@ -1,0 +1,205 @@
+
+SET ANSI_NULLS ON
+SET QUOTED_IDENTIFIER ON
+IF OBJECT_ID(N'dbo.BlacklistedMobs', N'U') IS NULL
+BEGIN
+CREATE TABLE[dbo].[BlacklistedMobs](
+	[Guid] [nvarchar](max) NOT NULL,
+	[Id] [int] IDENTITY(1,1) NOT NULL
+) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+END
+
+SET ANSI_NULLS ON
+SET QUOTED_IDENTIFIER ON
+IF OBJECT_ID(N'dbo.Commands', N'U') IS NULL
+BEGIN
+CREATE TABLE [dbo].[Commands](
+	[Id] [int] IDENTITY(1,1) NOT NULL,
+	[Command] [nvarchar](max) NOT NULL,
+	[Player] [nvarchar](max) NOT NULL,
+	[Args] [nvarchar](max) NULL
+) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+END
+/****** Object:  Table [dbo].[Hotspots]    Script Date: 12/3/2022 9:55:06 PM ******/
+SET ANSI_NULLS ON
+
+SET QUOTED_IDENTIFIER ON
+IF OBJECT_ID(N'dbo.Hotspots', N'U') IS NULL
+BEGIN
+CREATE TABLE [dbo].[Hotspots](
+	[Zone] [nvarchar](max) NOT NULL,
+	[Description] [nvarchar](max) NOT NULL,
+	[Faction] [nvarchar](max) NOT NULL,
+	[Waypoints] [nvarchar](max) NOT NULL,
+	[InnkeeperId] [int] NULL,
+	[RepairVendorId] [int] NULL,
+	[AmmoVendorId] [int] NULL,
+	[MinimumLevel] [int] NOT NULL,
+	[TravelPathId] [int] NULL,
+	[SafeForGrinding] [int] NOT NULL,
+	[Id] [int] IDENTITY(1,1) NOT NULL
+) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+END
+/****** Object:  Table [dbo].[HotspotsV2]    Script Date: 12/3/2022 9:55:06 PM ******/
+SET ANSI_NULLS ON
+
+SET QUOTED_IDENTIFIER ON
+IF OBJECT_ID(N'dbo.HotspotsV2', N'U') IS NULL
+BEGIN
+CREATE TABLE [dbo].[HotspotsV2](
+	[Id] [int] IDENTITY(1,1) NOT NULL,
+	[Polyn] [nvarchar](max) NOT NULL,
+	[Zone] [nvarchar](max) NOT NULL,
+	[Description] [nvarchar](max) NOT NULL,
+	[Faction] [nvarchar](max) NOT NULL,
+	[MinimumLevel] [int] NOT NULL,
+	[TravelPathId] [int] NULL,
+	[TownId] [int] NOT NULL
+) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+END
+/****** Object:  Table [dbo].[Kills]    Script Date: 12/3/2022 9:55:06 PM ******/
+SET ANSI_NULLS ON
+
+SET QUOTED_IDENTIFIER ON
+IF OBJECT_ID(N'dbo.Kills', N'U') IS NULL
+BEGIN
+CREATE TABLE [dbo].[Kills](
+	[PlayerLevel] [int] NOT NULL,
+	[PlayerName] [nvarchar](max) NOT NULL,
+	[PlayerClass] [nvarchar](max) NOT NULL,
+	[EnemyName] [nvarchar](max) NOT NULL,
+	[EnemyLevel] [int] NOT NULL,
+	[EnemyType] [nvarchar](max) NOT NULL,
+	[HealthPercentLost] [int] NOT NULL,
+	[CombatDuration] [int] NOT NULL,
+	[Id] [int] IDENTITY(1,1) NOT NULL
+) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+END
+/****** Object:  Table [dbo].[Npcs]    Script Date: 12/3/2022 9:55:06 PM ******/
+SET ANSI_NULLS ON
+
+SET QUOTED_IDENTIFIER ON
+IF OBJECT_ID(N'dbo.Npcs', N'U') IS NULL
+BEGIN
+CREATE TABLE [dbo].[Npcs](
+	[Name] [nvarchar](max) NOT NULL,
+	[IsInnkeeper] [bit] NOT NULL,
+	[SellsAmmo] [bit] NOT NULL,
+	[Repairs] [bit] NOT NULL,
+	[Quest] [bit] NOT NULL,
+	[Horde] [bit] NOT NULL,
+	[Alliance] [bit] NOT NULL,
+	[PositionX] [numeric](18, 0) NOT NULL,
+	[PositionY] [numeric](18, 0) NOT NULL,
+	[PositionZ] [numeric](18, 0) NOT NULL,
+	[Zone] [nvarchar](max) NOT NULL,
+	[Id] [int] IDENTITY(1,1) NOT NULL
+) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+END
+/****** Object:  Table [dbo].[QuestCompletions]    Script Date: 12/3/2022 9:55:06 PM ******/
+SET ANSI_NULLS ON
+
+SET QUOTED_IDENTIFIER ON
+IF OBJECT_ID(N'dbo.QuestCompletions', N'U') IS NULL
+BEGIN
+CREATE TABLE [dbo].[QuestCompletions](
+	[PlayerGuid] [nvarchar](max) NOT NULL,
+	[QuestId] [int] NOT NULL,
+	[Id] [int] IDENTITY(1,1) NOT NULL
+) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+END
+/****** Object:  Table [dbo].[QuestHubs]    Script Date: 12/3/2022 9:55:06 PM ******/
+SET ANSI_NULLS ON
+
+SET QUOTED_IDENTIFIER ON
+IF OBJECT_ID(N'dbo.QuestHubs', N'U') IS NULL
+BEGIN
+CREATE TABLE [dbo].[QuestHubs](
+	[Name] [nvarchar](max) NOT NULL,
+	[Id] [int] IDENTITY(1,1) NOT NULL
+) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+END
+/****** Object:  Table [dbo].[QuestObjectives]    Script Date: 12/3/2022 9:55:06 PM ******/
+SET ANSI_NULLS ON
+
+SET QUOTED_IDENTIFIER ON
+IF OBJECT_ID(N'dbo.QuestObjectives', N'U') IS NULL
+BEGIN
+CREATE TABLE [dbo].[QuestObjectives](
+	[Type] [nvarchar](max) NOT NULL,
+	[Name] [nvarchar](max) NOT NULL,
+	[Source] [nvarchar](max) NOT NULL,
+	[Quantity] [int] NOT NULL,
+	[QuestId] [int] NOT NULL,
+	[ObjectId] [int] NOT NULL,
+	[Id] [int] IDENTITY(1,1) NOT NULL
+) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+END
+/****** Object:  Table [dbo].[QuestPrerequisites]    Script Date: 12/3/2022 9:55:06 PM ******/
+SET ANSI_NULLS ON
+
+SET QUOTED_IDENTIFIER ON
+IF OBJECT_ID(N'dbo.QuestPrerequisites', N'U') IS NULL
+BEGIN
+CREATE TABLE [dbo].[QuestPrerequisites](
+	[ParentId] [int] NOT NULL,
+	[ChildId] [int] NOT NULL,
+	[Id] [int] IDENTITY(1,1) NOT NULL
+) ON [PRIMARY]
+END
+/****** Object:  Table [dbo].[Quests]    Script Date: 12/3/2022 9:55:06 PM ******/
+SET ANSI_NULLS ON
+
+SET QUOTED_IDENTIFIER ON
+IF OBJECT_ID(N'dbo.Quests', N'U') IS NULL
+BEGIN
+CREATE TABLE [dbo].[Quests](
+	[Name] [nvarchar](max) NOT NULL,
+	[QuestHubId] [int] NOT NULL,
+	[HotspotId] [int] NULL,
+	[StartNpcId] [int] NOT NULL,
+	[EndNpcId] [int] NOT NULL,
+	[RequiredLevel] [int] NOT NULL,
+	[Class] [nvarchar](max) NOT NULL,
+	[QuestId] [int] NOT NULL,
+	[Id] [int] IDENTITY(1,1) NOT NULL
+) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+END
+/****** Object:  Table [dbo].[ReportSignatures]    Script Date: 12/3/2022 9:55:06 PM ******/
+SET ANSI_NULLS ON
+
+SET QUOTED_IDENTIFIER ON
+IF OBJECT_ID(N'dbo.ReportSignatures', N'U') IS NULL
+BEGIN
+CREATE TABLE [dbo].[ReportSignatures](
+	[Id] [int] IDENTITY(1,1) NOT NULL,
+	[Player] [nvarchar](max) NOT NULL,
+	[CommandId] [int] NOT NULL
+) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+END
+/****** Object:  Table [dbo].[Towns]    Script Date: 12/3/2022 9:55:06 PM ******/
+SET ANSI_NULLS ON
+
+SET QUOTED_IDENTIFIER ON
+IF OBJECT_ID(N'dbo.Towns', N'U') IS NULL
+BEGIN
+CREATE TABLE [dbo].[Towns](
+	[Id] [int] IDENTITY(1,1) NOT NULL,
+	[InnkeeperId] [int] NULL,
+	[RepairVendorId] [int] NULL,
+	[AmmoVendorId] [int] NULL,
+	[Name] [nvarchar](max) NULL
+) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+END
+/****** Object:  Table [dbo].[TravelPaths]    Script Date: 12/3/2022 9:55:06 PM ******/
+SET ANSI_NULLS ON
+
+SET QUOTED_IDENTIFIER ON
+IF OBJECT_ID(N'dbo.TravelPaths', N'U') IS NULL
+BEGIN
+CREATE TABLE [dbo].[TravelPaths](
+	[Name] [nvarchar](max) NOT NULL,
+	[Waypoints] [nvarchar](max) NOT NULL,
+	[Id] [int] IDENTITY(1,1) NOT NULL
+) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+END

--- a/BloogBot/UI/MainViewModel.cs
+++ b/BloogBot/UI/MainViewModel.cs
@@ -33,7 +33,7 @@ namespace BloogBot.UI
             UpdatePropertiesWithAttribute(typeof(BotSettingAttribute));
 
             Logger.Initialize(botSettings);
-            Repository.Initialize(botSettings.DatabasePath);
+            Repository.Initialize(botSettings.DatabaseType,botSettings.DatabasePath);
             DiscordClientWrapper.Initialize(botSettings);
             TravelPathGenerator.Initialize(() =>
             {

--- a/BloogBot/botSettings.json
+++ b/BloogBot/botSettings.json
@@ -1,5 +1,7 @@
 {
+  "DatabaseType": "sqlite", // 'sqlite' or 'mysql' currently. Database path is unused if sqlite is selected as a local database is created.
   "DatabasePath": "Server=tcp:bloog-bot.database.windows.net,1433;Initial Catalog=BloogBot;Persist Security Info=False;User ID=dkestell;Password=<>;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;",
+  "DiscordBotEnabled": false,
   "DiscordBotToken": "<>",
   "DiscordGuildId": "303695206333546496",
   "DiscordRoleId": "707118407157284936",

--- a/BloogBot/botSettings.json
+++ b/BloogBot/botSettings.json
@@ -1,5 +1,5 @@
 {
-  "DatabaseType": "sqlite", // 'sqlite' or 'mysql' currently. Database path is unused if sqlite is selected as a local database is created.
+  "DatabaseType": "sqlite", // 'sqlite' or 'mssql' (Microsoft SQL/Transact SQL) currently. Database path is unused if sqlite is selected as a local database is created.
   "DatabasePath": "Server=tcp:bloog-bot.database.windows.net,1433;Initial Catalog=BloogBot;Persist Security Info=False;User ID=dkestell;Password=<>;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;",
   "DiscordBotEnabled": false,
   "DiscordBotToken": "<>",

--- a/BloogBot/packages.config
+++ b/BloogBot/packages.config
@@ -3,9 +3,15 @@
   <package id="Discord.Net.Core" version="2.2.0" targetFramework="net461" />
   <package id="Discord.Net.Rest" version="2.2.0" targetFramework="net461" />
   <package id="Discord.Net.WebSocket" version="2.2.0" targetFramework="net461" />
+  <package id="EntityFramework" version="6.4.4" targetFramework="net461" />
   <package id="Microsoft.Bcl.AsyncInterfaces" version="1.0.0" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net461" />
+  <package id="Stub.System.Data.SQLite.Core.NetFramework" version="1.0.117.0" targetFramework="net461" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net461" />
+  <package id="System.Data.SQLite" version="1.0.117.0" targetFramework="net461" />
+  <package id="System.Data.SQLite.Core" version="1.0.117.0" targetFramework="net461" />
+  <package id="System.Data.SQLite.EF6" version="1.0.117.0" targetFramework="net461" />
+  <package id="System.Data.SQLite.Linq" version="1.0.117.0" targetFramework="net461" />
   <package id="System.Interactive.Async" version="4.0.0" targetFramework="net461" />
   <package id="System.Linq.Async" version="4.0.0" targetFramework="net461" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net461" />

--- a/FastCall/FastCall.vcxproj
+++ b/FastCall/FastCall.vcxproj
@@ -86,7 +86,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
@@ -115,7 +115,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <PrecompiledHeader>Use</PrecompiledHeader>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>

--- a/FastCall/FastCall.vcxproj
+++ b/FastCall/FastCall.vcxproj
@@ -23,13 +23,13 @@
     <ProjectGuid>{C5ED9E2F-C166-4D4C-9E65-47035C38B3EA}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>FastCall</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
@@ -42,13 +42,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/Loader/Loader.vcxproj
+++ b/Loader/Loader.vcxproj
@@ -23,13 +23,13 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{c817858e-0656-4211-934b-c672998eddb3}</ProjectGuid>
     <RootNamespace>Loader</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
@@ -41,13 +41,13 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Loader/dllmain.cpp
+++ b/Loader/dllmain.cpp
@@ -57,6 +57,27 @@ unsigned __stdcall ThreadMain(void* pParam)
 	AllocConsole();
 	freopen("CONOUT$", "w", stdout);
 
+#if _DEBUG
+	std::cout << std::string("Attach a debugger now to WoW.exe if you want to debug Loader.dll. Waiting 10 seconds...") << std::endl;
+
+	HANDLE hEvent = CreateEvent(nullptr, TRUE, FALSE, L"MyDebugEvent");
+	WaitForSingleObject(hEvent, 10000);  // Wait for 10 seconds
+	bool isDebuggerAttached = IsDebuggerPresent() != FALSE;
+
+	if (isDebuggerAttached)
+	{
+		std::cout << std::string("Debugger found.") << std::endl;
+	}
+	else
+	{
+		std::cout << std::string("Debugger not found.") << std::endl;
+	}
+
+	SetEvent(hEvent);
+	CloseHandle(hEvent);
+#endif
+
+
 	HRESULT hr = CLRCreateInstance(CLSID_CLRMetaHostPolicy, IID_ICLRMetaHostPolicy, (LPVOID*)&g_pMetaHost);
 
 	if (FAILED(hr))

--- a/Navigation/Navigation.vcxproj
+++ b/Navigation/Navigation.vcxproj
@@ -14,7 +14,7 @@
     <ProjectGuid>{8E623BB1-1B7B-4F8E-A051-72F53A9AB620}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>Navigation</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
@@ -28,7 +28,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>false</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
     <CLRSupport>false</CLRSupport>

--- a/NavigationTests/NavigationTests.vcxproj
+++ b/NavigationTests/NavigationTests.vcxproj
@@ -23,14 +23,14 @@
     <ProjectGuid>{339B8C16-CAD4-467B-B1F3-F10F7E80F944}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>NavigationTests</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.16299.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ProjectSubType>NativeUnitTestProject</ProjectSubType>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
     <UseOfMfc>false</UseOfMfc>
   </PropertyGroup>
@@ -45,14 +45,14 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>false</UseOfMfc>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
     <UseOfMfc>false</UseOfMfc>


### PR DESCRIPTION
Added:

- BotSettings 'DiscordBotEnabled' & 'DatabaseType' (sqlite or mssql)
- DatabaseWrapper class that handles all requests to save/retrieve data depending on DatabaseType, with flexibility to add new storage types.
- Sql Schema files for both mssql and sqlite which automatically set up necessary tables in database.

General flow:
- User sets up database type in settings
- On initialisation, depending on database type, new SQLite database is created and/or local .SQL script run to create all necessary tables
- On data request, repository passes arguments into corresponding database wrapper method.
- Database wrapper methods contain logic that retrieves data based on database type and passes it back through in expected format.