### PR TITLE
Separate npc types in select list to make the ui less busy

### DIFF
--- a/BloogBot/UI/MainViewModel.cs
+++ b/BloogBot/UI/MainViewModel.cs
@@ -3,6 +3,7 @@ using BloogBot.Game;
 using BloogBot.Game.Objects;
 using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
@@ -10,6 +11,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows.Documents;
 using System.Windows.Input;
 
 namespace BloogBot.UI
@@ -514,18 +516,7 @@ namespace BloogBot.UI
                         target.Position.Z,
                         ObjectManager.ZoneText);
 
-                    if (npcIsInnkeeper)
-                    {
-                        InkeeperNpcs.Add(npc);
-                    }
-                    if (npcSellsAmmo)
-                    {
-                        AmmoNpcs.Add(npc);
-                    }
-                    if (npcRepairs)
-                    {
-                        RepairNpcs.Add(npc);
-                    }
+                    InitializeNpcs();
                     Log("NPC saved successfully!");
                 }
                 else

--- a/BloogBot/UI/MainViewModel.cs
+++ b/BloogBot/UI/MainViewModel.cs
@@ -63,7 +63,9 @@ namespace BloogBot.UI
         public ObservableCollection<IBot> Bots { get; private set; }
         public ObservableCollection<TravelPath> TravelPaths { get; private set; }
         public ObservableCollection<Hotspot> Hotspots { get; private set; }
-        public ObservableCollection<Npc> Npcs { get; private set; }
+        public ObservableCollection<Npc> RepairNpcs { get; private set; }
+        public ObservableCollection<Npc> InkeeperNpcs { get; private set; }
+        public ObservableCollection<Npc> AmmoNpcs { get; private set; }
 
         #region Commands
 
@@ -512,12 +514,18 @@ namespace BloogBot.UI
                         target.Position.Z,
                         ObjectManager.ZoneText);
 
-                    Npcs.Add(npc);
-                    Npcs = new ObservableCollection<Npc>(Npcs.OrderBy(n => n?.Horde)
-                        .ThenBy(n => n?.Name));
-
-                    OnPropertyChanged(nameof(Npcs));
-
+                    if (npcIsInnkeeper)
+                    {
+                        InkeeperNpcs.Add(npc);
+                    }
+                    if (npcSellsAmmo)
+                    {
+                        AmmoNpcs.Add(npc);
+                    }
+                    if (npcRepairs)
+                    {
+                        RepairNpcs.Add(npc);
+                    }
                     Log("NPC saved successfully!");
                 }
                 else
@@ -1437,14 +1445,23 @@ namespace BloogBot.UI
         {
             var npcs = Repository.ListNpcs()
                 .OrderBy(n => n.Horde)
-                .ThenBy(n => n.IsInnkeeper)
-                .ThenBy(n => n.Repairs)
-                .ThenBy(n => n.SellsAmmo)
                 .ThenBy(n => n.Name);
 
-            Npcs = new ObservableCollection<Npc>(npcs);
-            Npcs.Insert(0, null);
-            OnPropertyChanged(nameof(Npcs));
+            var repairNpcs = npcs.Where(n => n.Repairs);
+            var inkeeperNpcs = npcs.Where(n => n.IsInnkeeper);
+            var ammoNpcs = npcs.Where(n => n.SellsAmmo);
+
+            RepairNpcs = new ObservableCollection<Npc>(repairNpcs);
+            InkeeperNpcs = new ObservableCollection<Npc>(inkeeperNpcs);
+            AmmoNpcs = new ObservableCollection<Npc>(ammoNpcs);
+
+            RepairNpcs.Insert(0, null);
+            InkeeperNpcs.Insert(0, null);
+            AmmoNpcs.Insert(0, null);
+
+            OnPropertyChanged(nameof(RepairNpcs));
+            OnPropertyChanged(nameof(InkeeperNpcs));
+            OnPropertyChanged(nameof(AmmoNpcs));
         }
 
         public void InitializeObjectManager()

--- a/BloogBot/UI/MainWindow.xaml
+++ b/BloogBot/UI/MainWindow.xaml
@@ -1072,7 +1072,7 @@
                             IsEditable="False"
                             VerticalContentAlignment="Center"
                             SelectedItem="{Binding Path=NewHotspotInnkeeper, Mode=TwoWay}"
-                            ItemsSource="{Binding Path=Npcs, Mode=OneWay}">
+                            ItemsSource="{Binding Path=InkeeperNpcs, Mode=OneWay}">
                             <ComboBox.ItemTemplate>
                                 <DataTemplate>
                                     <TextBlock>
@@ -1098,7 +1098,7 @@
                             IsEditable="False"
                             VerticalContentAlignment="Center"
                             SelectedItem="{Binding Path=NewHotspotRepairVendor, Mode=TwoWay}"
-                            ItemsSource="{Binding Path=Npcs, Mode=OneWay}">
+                            ItemsSource="{Binding Path=RepairNpcs, Mode=OneWay}">
                             <ComboBox.ItemTemplate>
                                 <DataTemplate>
                                     <TextBlock>
@@ -1124,7 +1124,7 @@
                             IsEditable="False"
                             VerticalContentAlignment="Center"
                             SelectedItem="{Binding Path=NewHotspotAmmoVendor, Mode=TwoWay}"
-                            ItemsSource="{Binding Path=Npcs, Mode=OneWay}">
+                            ItemsSource="{Binding Path=AmmoNpcs, Mode=OneWay}">
                             <ComboBox.ItemTemplate>
                                 <DataTemplate>
                                     <TextBlock>


### PR DESCRIPTION
A small UI change to just separate the NPC types in the dropdowns.

![image](https://github.com/DrewKestell/BloogBot/assets/9095570/e6f59d22-3622-40b5-a0a8-57d2689d9e7d)

![image](https://github.com/DrewKestell/BloogBot/assets/9095570/feb010b7-1a58-4bd8-85ba-19672b25af91)

![image](https://github.com/DrewKestell/BloogBot/assets/9095570/7aa717a9-38dc-45f8-963d-3c17133b9b08)
