### PR TITLE
BeastmasterHunterBot: LOS checks, pet management, rest state rewrite

### DIFF
--- a/BeastmasterHunterBot/CombatState.cs
+++ b/BeastmasterHunterBot/CombatState.cs
@@ -15,9 +15,6 @@ namespace BeastMasterHunterBot
     {
         const string AutoAttackLuaScript = "if IsCurrentAction('84') == nil then CastSpellByName('Attack') end";
         const string GunLuaScript = "if IsAutoRepeatAction(11) == nil then CastSpellByName('Auto Shot') end"; // 8-35 yards
-        const string LosErrorMessage = "Target not in line of sight";
-        const string OutOfAmmoErrorMessage = "Ammo needs to be in the paper doll ammo slot before it can be fired";
-
         const string RaptorStrike = "Raptor Strike";
         const string ArcaneShot = "Arcane Shot";
         const string SerpentSting = "Serpent Sting";
@@ -43,7 +40,7 @@ namespace BeastMasterHunterBot
             Stack<IBotState> botStates,
             IDependencyContainer container,
             WoWUnit target,
-            bool loot = true) : base(botStates, container, target, 30, loot)
+            bool loot = true) : base(botStates, container, target, 28, loot)
         {
             player = ObjectManager.Player;
             this.target = target;
@@ -55,25 +52,34 @@ namespace BeastMasterHunterBot
             if (base.Update())
                 return;
 
-            Console.WriteLine("foo");
+            var pet = ObjectManager.Pet;
+            if (pet != null && pet.HealthPercent > 0 && pet.HealthPercent < 75
+                && player.Position.DistanceTo(pet.Position) <= 10
+                && !pet.HasBuff(MendPet))
+            {
+                TryCastSpell(MendPet, 0, int.MaxValue);
+            }
 
             var gun = Inventory.GetEquippedItem(EquipSlot.Ranged);
             var canUseRanged = gun != null && player.Position.DistanceTo(target.Position) > 5 && player.Position.DistanceTo(target.Position) < 34;
+
             if (gun == null)
             {
                 player.LuaCall(AutoAttackLuaScript);
             }
-            else if (canUseRanged && player.ManaPercent < 60)
+            else if (canUseRanged)
             {
+                // Proactive LOS check: if we can't see the target, move toward it until we can
+                if (!player.InLosWith(target.Position))
+                {
+                    var nextWaypoint = Navigation.GetNextWaypoint(ObjectManager.MapId, player.Position, target.Position, false);
+                    player.MoveToward(nextWaypoint);
+                    return;
+                }
+
+                // Always keep Auto Shot toggled on during ranged combat
                 player.LuaCall(GunLuaScript);
-            }
-            else if (gun != null && canUseRanged)
-            {
-                //if (!target.HasDebuff(HuntersMark)) 
-                //{
-                //     TryCastSpell(HuntersMark, 0, 34);
-                //}
-                //else 
+
                 if (!target.HasDebuff(SerpentSting))
                 {
                     TryCastSpell(SerpentSting, 0, 34);
@@ -82,10 +88,6 @@ namespace BeastMasterHunterBot
                 {
                     TryCastSpell(ArcaneShot, 0, 34);
                 }
-                return;
-
-
-                //TryCastSpell(ConcussiveShot, 0, 34);
             }
             else
             {

--- a/BeastmasterHunterBot/MoveToTargetState.cs
+++ b/BeastmasterHunterBot/MoveToTargetState.cs
@@ -43,7 +43,7 @@ namespace BeastMasterHunterBot
             stuckHelper.CheckIfStuck();
 
             var distanceToTarget = player.Position.DistanceTo(target.Position);
-            if (distanceToTarget < 33 && !player.IsCasting)
+            if (distanceToTarget < 33 && player.InLosWith(target.Position) && !player.IsCasting)
             {
                 player.StopAllMovement();
                 player.LuaCall(GunLuaScript);

--- a/BeastmasterHunterBot/RestState.cs
+++ b/BeastmasterHunterBot/RestState.cs
@@ -15,22 +15,19 @@ namespace BeastMasterHunterBot
     {
         const int stackCount = 5;
 
-        const string noPetErrorMessage = "You do not have a pet";
+        const string MendPet = "Mend Pet";
 
         readonly Stack<IBotState> botStates;
         readonly IDependencyContainer container;
         readonly LocalPlayer player;
-        readonly LocalPet pet;
-        readonly WoWItem foodItem;
-        readonly WoWItem drinkItem;
-        readonly WoWItem petFood;
+        WoWItem foodItem;
+        WoWItem drinkItem;
 
         public RestState(Stack<IBotState> botStates, IDependencyContainer container)
         {
             this.botStates = botStates;
             this.container = container;
             player = ObjectManager.Player;
-            pet = ObjectManager.Pet;
 
             foodItem = Inventory.GetAllItems()
                 .FirstOrDefault(i => i.Info.Name == container.BotSettings.Food);
@@ -41,24 +38,43 @@ namespace BeastMasterHunterBot
 
         public void Update()
         {
-            // Check on your pet
-            if (pet != null && !PetHappy && !PetBeingFed)
-            {
-                
-            }
-            if (player.HealthPercent >= 95 ||
-                player.HealthPercent >= 80 && !player.IsEating ||
-                ObjectManager.Player.IsInCombat ||
-                ObjectManager.Units.Any(u => u.TargetGuid == ObjectManager.Player.Guid))
+            if (InCombat)
             {
                 Wait.RemoveAll();
                 player.Stand();
                 botStates.Pop();
+                return;
+            }
+
+            var pet = ObjectManager.Pet;
+            if (pet != null && !pet.IsHappy() && !pet.HasBuff("Feed Pet Effect") && Wait.For("FeedPetDelay", 3000, true))
+            {
+                FeedPet();
+            }
+
+            if (foodItem != null && !player.IsEating && player.HealthPercent < 80 && Wait.For("EatDelay", 2000, true))
+                foodItem.Use();
+
+            if (drinkItem != null && !player.IsDrinking && player.ManaPercent < 80 && Wait.For("DrinkDelay", 2000, true))
+                drinkItem.Use();
+
+            if (pet != null && pet.HealthPercent > 0 && pet.HealthPercent < 90
+                && !pet.HasBuff(MendPet) && player.IsSpellReady(MendPet))
+            {
+                player.LuaCall($"CastSpellByName('{MendPet}')");
+            }
+
+            if (HealthOk && ManaOk && PetHealthOk)
+            {
+                Wait.RemoveAll();
+                player.Stand();
+                botStates.Pop();
+                botStates.Push(new BuffSelfState(botStates, container));
 
                 var foodCount = foodItem == null ? 0 : Inventory.GetItemCount(foodItem.ItemId);
                 var drinkCount = drinkItem == null ? 0 : Inventory.GetItemCount(drinkItem.ItemId);
 
-                if (!InCombat && (foodCount == 0 || drinkCount == 0) && !container.RunningErrands)
+                if (foodCount == 0 || drinkCount == 0)
                 {
                     var foodToBuy = 12 - (foodCount / stackCount);
                     var drinkToBuy = 28 - (drinkCount / stackCount);
@@ -85,14 +101,35 @@ namespace BeastMasterHunterBot
 
                 return;
             }
-
-            if (foodItem != null && !ObjectManager.Player.IsEating && Wait.For("EatDelay", 250, true))
-                foodItem.Use();
         }
 
-        bool InCombat => ObjectManager.Aggressors.Count() > 0;
-        bool PetHealthOk => ObjectManager.Pet == null || ObjectManager.Pet.HealthPercent >= 80;
-        bool PetHappy => pet.IsHappy();
-        bool PetBeingFed => pet.HasBuff("Feed Pet Effect");
+        void FeedPet()
+        {
+            if (string.IsNullOrEmpty(container.BotSettings.Food)) return;
+
+            var foodName = container.BotSettings.Food;
+
+            player.LuaCall("CastSpellByName('Feed Pet')");
+            player.LuaCall(
+                "for bag = 0,4 do for slot = 1,GetContainerNumSlots(bag) do local item = GetContainerItemLink(bag,slot) " +
+                "if item then if string.find(item, '" + foodName.Replace("'", "\\'") + "') then " +
+                "PickupContainerItem(bag,slot) break end end end end");
+            player.LuaCall("ClearCursor()");
+        }
+
+        bool HealthOk => foodItem == null || player.HealthPercent >= 95 || (player.HealthPercent >= 80 && !player.IsEating);
+
+        bool ManaOk => drinkItem == null || player.ManaPercent >= 95 || (player.ManaPercent >= 80 && !player.IsDrinking);
+
+        bool InCombat => ObjectManager.Player.IsInCombat || ObjectManager.Units.Any(u => u.TargetGuid == ObjectManager.Player.Guid);
+
+        bool PetHealthOk
+        {
+            get
+            {
+                var pet = ObjectManager.Pet;
+                return pet == null || pet.HealthPercent == 0 || pet.HealthPercent >= 90;
+            }
+        }
     }
 }


### PR DESCRIPTION
CombatState:
- Add proactive LOS check: if the target isn't in line of sight, navigate toward it rather than standing still burning the ranged GCD
- Always toggle Auto Shot during ranged combat regardless of mana percent
- Cast Mend Pet when pet health drops below 75% and player is within 10 yards
- Remove dead LosErrorMessage/OutOfAmmoErrorMessage constants and Console.WriteLine("foo") debug line
- Reduce base engagement range from 30 to 28 to give navigation more room

MoveToTargetState:
- Require player.InLosWith(target.Position) before stopping movement to shoot, preventing the bot from halting against terrain with no clear shot

RestState (full rewrite):
- Look up pet, food, and drink references each tick so newly acquired items and a freshly-summoned pet are picked up without re-entering state
- Feed pet via Feed Pet spell + Lua bag scan when pet is unhappy and not already being fed; guard with a 3-second Wait.For to avoid spam
- Cast Mend Pet during rest when pet health is below 90%
- Exit to BuffSelfState instead of directly to idle, matching other bots
- Correct HealthOk/ManaOk/PetHealthOk conditions (treat missing food/drink item as "ok" rather than blocking rest exit)
- Remove RunningErrands guard on supply errand push (state machine handles re-entry correctly without it)